### PR TITLE
Update various project use modals with install cmd

### DIFF
--- a/elm-git.json
+++ b/elm-git.json
@@ -1,7 +1,7 @@
 {
     "git-dependencies": {
         "direct": {
-            "https://github.com/unisonweb/ui-core": "6f70efd9c3909698ec8a31f90fd39564806e5d21"
+            "https://github.com/unisonweb/ui-core": "2f995e1248684ad17dd23298bdb8cd09904eca6e"
         },
         "indirect": {}
     }

--- a/src/UnisonShare/Page/ProjectOverviewPage.elm
+++ b/src/UnisonShare/Page/ProjectOverviewPage.elm
@@ -54,6 +54,7 @@ import UnisonShare.Project.ProjectListing as ProjectListing
 import UnisonShare.Project.ProjectRef as ProjectRef exposing (ProjectRef)
 import UnisonShare.Route as Route
 import UnisonShare.Session as Session exposing (Session)
+import UnisonShare.UcmCommand as UcmCommand
 
 
 
@@ -509,10 +510,10 @@ viewReadmeInstructionsModal projectRef =
                 ]
 
         pushCommand =
-            "push " ++ ProjectRef.toString projectRef
+            UcmCommand.Push projectRef Nothing |> UcmCommand.toString
 
         pullCommand =
-            "pull " ++ ProjectRef.toString projectRef
+            UcmCommand.Pull projectRef Nothing |> UcmCommand.toString
 
         step2 =
             Steps.step "Push the README to Unison Share"

--- a/src/UnisonShare/Page/ProjectReleasePage.elm
+++ b/src/UnisonShare/Page/ProjectReleasePage.elm
@@ -1,10 +1,10 @@
 module UnisonShare.Page.ProjectReleasePage exposing (..)
 
 import Browser.Dom as Dom
+import Code.BranchRef as BranchRef
 import Code.Definition.Doc as Doc exposing (Doc)
 import Code.Hash as Hash
 import Code.Perspective as Perspective
-import Code.ProjectSlug as ProjectSlug
 import Code.Version as Version exposing (Version)
 import Html exposing (Html, div, p, section, span, strong, text)
 import Html.Attributes exposing (class, classList, id)
@@ -35,6 +35,7 @@ import UnisonShare.PageFooter as PageFooter
 import UnisonShare.Project.ProjectRef as ProjectRef exposing (ProjectRef)
 import UnisonShare.Project.Release as Release exposing (Release)
 import UnisonShare.Route as Route
+import UnisonShare.UcmCommand as UcmCommand
 
 
 
@@ -367,25 +368,19 @@ viewInstallModal projectRef version =
         projectRef_ =
             ProjectRef.toString projectRef
 
-        pullCommand =
-            "pull "
-                ++ projectRef_
-                ++ "/releases/"
-                ++ Version.toString version
-                ++ " lib."
-                ++ ProjectSlug.toNamespaceString (ProjectRef.slug projectRef)
-                ++ "_"
-                ++ Version.toNamespaceString version
+        installCommand =
+            UcmCommand.Install projectRef (Just (BranchRef.releaseBranchRef version))
+                |> UcmCommand.toString
 
         content =
             Modal.Content
                 (div [ class "use-project-modal-content" ]
                     [ p []
                         [ text "From within your project in UCM, run the "
-                        , strong [] [ text "pull" ]
+                        , strong [] [ text "lib.install" ]
                         , text " command:"
                         ]
-                    , CopyField.copyField (\_ -> NoOp) pullCommand |> CopyField.withPrefix "myProject/main>" |> CopyField.view
+                    , CopyField.copyField (\_ -> NoOp) installCommand |> CopyField.withPrefix "myProject/main>" |> CopyField.view
                     , div [ class "hint" ] [ text "Copy and paste this command into UCM." ]
                     , Divider.divider |> Divider.small |> Divider.view
                     , div [ class "action" ] [ Button.iconThenLabel CloseModal Icon.thumbsUp "Got it!" |> Button.emphasized |> Button.view ]

--- a/src/UnisonShare/Page/ProjectReleasesPage.elm
+++ b/src/UnisonShare/Page/ProjectReleasesPage.elm
@@ -12,6 +12,7 @@ import Html.Attributes exposing (class, classList, id)
 import Http
 import Json.Decode as Decode
 import Lib.HttpApi as HttpApi
+import Lib.UserHandle as UserHandle
 import Lib.Util as Util
 import List.Nonempty as NEL
 import Maybe.Extra as MaybeE
@@ -46,6 +47,7 @@ import UnisonShare.Project.Release as Release exposing (Release)
 import UnisonShare.PublishProjectReleaseModal as PublishProjectReleaseModal
 import UnisonShare.Route as Route
 import UnisonShare.Session as Session
+import UnisonShare.UcmCommand as UcmCommand
 
 
 
@@ -798,33 +800,30 @@ viewInstallModal projectRef version =
             ProjectRef.toString projectRef
 
         libVersion =
-            "lib."
+            UserHandle.toString (ProjectRef.handle projectRef)
+                ++ "_"
                 ++ ProjectSlug.toNamespaceString (ProjectRef.slug projectRef)
                 ++ "_"
                 ++ Version.toNamespaceString version
 
-        pullCommand =
-            "pull "
-                ++ projectRef_
-                ++ "/releases/"
-                ++ Version.toString version
-                ++ " lib."
-                ++ libVersion
+        installCommand =
+            UcmCommand.Install projectRef (Just (BranchRef.releaseBranchRef version))
+                |> UcmCommand.toString
 
         content =
             Modal.Content
                 (div [ class "instruction" ]
                     [ p []
                         [ text "From within your project in UCM, run the "
-                        , strong [] [ text "pull" ]
+                        , strong [] [ text "lib.install" ]
                         , text " command:"
                         ]
-                    , CopyField.copyField (\_ -> NoOp) pullCommand |> CopyField.withPrefix "myProject/main>" |> CopyField.view
+                    , CopyField.copyField (\_ -> NoOp) installCommand |> CopyField.withPrefix "myProject/main>" |> CopyField.view
                     , div [ class "hint" ] [ text "Copy and paste this command into UCM." ]
                     , div [ class "upgrade-hint" ]
                         [ div [ class "upgrade-icon" ] [ Icon.view Icon.arrowUp ]
                         , div [ class "upgrade-hint_content" ]
-                            [ div [] [ text "Upgrading from a previous version? Pull using the above and then run:" ]
+                            [ div [] [ text "Upgrading from a previous version? Install using the above and then run:" ]
                             , div [ class "monospace" ] [ text ("myProject/main> upgrade <old_version> " ++ libVersion) ]
                             ]
                         ]

--- a/src/UnisonShare/UcmCommand.elm
+++ b/src/UnisonShare/UcmCommand.elm
@@ -1,0 +1,32 @@
+module UnisonShare.UcmCommand exposing (..)
+
+import Code.BranchRef as BranchRef exposing (BranchRef)
+import UnisonShare.Project.ProjectRef as ProjectRef exposing (ProjectRef)
+
+
+type UcmCommand
+    = Install ProjectRef (Maybe BranchRef)
+    | Pull ProjectRef (Maybe BranchRef)
+    | Push ProjectRef (Maybe BranchRef)
+
+
+toString : UcmCommand -> String
+toString command =
+    case command of
+        Install pr (Just br) ->
+            "lib.install " ++ ProjectRef.toString pr ++ "/" ++ BranchRef.toString br
+
+        Install pr Nothing ->
+            "lib.install " ++ ProjectRef.toString pr
+
+        Pull pr (Just br) ->
+            "pull " ++ ProjectRef.toString pr ++ "/" ++ BranchRef.toString br
+
+        Pull pr Nothing ->
+            "pull " ++ ProjectRef.toString pr
+
+        Push pr (Just br) ->
+            "push " ++ ProjectRef.toString pr ++ "/" ++ BranchRef.toString br
+
+        Push pr Nothing ->
+            "push " ++ ProjectRef.toString pr

--- a/src/css/unison-share/page/user-profile-page.css
+++ b/src/css/unison-share/page/user-profile-page.css
@@ -45,13 +45,6 @@
   border-radius: var(--border-radius-base);
 }
 
-.user-profile-page .readme-empty-state {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 1.5rem;
-}
-
 .user-profile-empty-state_welcome-to {
   text-align: center;
 }
@@ -74,42 +67,6 @@
   padding: 0.75rem;
   padding-top: 1.5rem;
   border-radius: var(--border-radius-base);
-}
-
-#user-profile-readme-instructions-modal {
-  width: 34.5rem;
-}
-#user-profile-readme-instructions-modal .steps {
-  margin-top: 1.5rem;
-}
-#user-profile-readme-instructions-modal .modal-actions {
-  margin-top: 1.5rem;
-  display: flex;
-  justify-content: flex-end;
-}
-
-#user-profile-readme-instructions-modal .pull-hint {
-  display: flex;
-  flex-direction: row;
-  gap: 0.5rem;
-  margin-top: 0.75rem;
-  color: var(--u-color_text_subdued);
-}
-
-#user-profile-readme-instructions-modal .pull-hint p:last-child {
-  margin: 0;
-}
-
-#user-profile-readme-instructions-modal .pull-hint .icon {
-  color: var(--u-color_icon_subdued);
-  flex-shrink: 0;
-  margin-top: 2px;
-}
-
-#user-profile-readme-instructions-modal .pull-hint .inline-code {
-  background: var(--color-gray-lighten-60);
-  border-radius: var(--border-radius-base);
-  padding: 0 0.3rem;
 }
 
 .user-profile-page .projects {


### PR DESCRIPTION
UCM added a new `lib.install` command and the various "use project" modals on Share now reflect this change (was previously `pull`).

---

⚠️ Do not merge until we release the next UCM version (which includes `lib.install`).