### PR TITLE
Improve upgrade instruction in project modal

### DIFF
--- a/src/UnisonShare/Page/ProjectPage.elm
+++ b/src/UnisonShare/Page/ProjectPage.elm
@@ -908,8 +908,7 @@ viewUseProjectModal project branchRef =
             ProjectRef.toString project.ref
 
         libVersion v =
-            "lib."
-                ++ ProjectSlug.toNamespaceString (ProjectRef.slug project.ref)
+            ProjectSlug.toNamespaceString (ProjectRef.slug project.ref)
                 ++ "_"
                 ++ Version.toNamespaceString v
 


### PR DESCRIPTION
## Problem

The `lib.` part in the upgrade section of the project modal is confusing, because it's not needed. Fixes https://github.com/unisoncomputing/share-ui/issues/9

## Solution

Removes the `lib.` part!