### PR TITLE
Add branch name for projects without a release

### DIFF
--- a/src/UnisonShare/Page/ProjectPage.elm
+++ b/src/UnisonShare/Page/ProjectPage.elm
@@ -924,8 +924,14 @@ viewUseProjectModal project branchRef =
 
         installCommand_ br =
             let
+                sameRelease =
+                  case (project.latestVersion, BranchRef.version br) of
+                    ( Just lv, Just bv ) ->
+                        lv == bv
+                    _ ->
+                        False
                 cmd =
-                    if project.latestVersion == BranchRef.version br then
+                    if sameRelease then
                         UcmCommand.Install project.ref Nothing
 
                     else

--- a/src/UnisonShare/Page/ProjectPage.elm
+++ b/src/UnisonShare/Page/ProjectPage.elm
@@ -925,11 +925,13 @@ viewUseProjectModal project branchRef =
         installCommand_ br =
             let
                 sameRelease =
-                  case (project.latestVersion, BranchRef.version br) of
-                    ( Just lv, Just bv ) ->
-                        lv == bv
-                    _ ->
-                        False
+                    case ( project.latestVersion, BranchRef.version br ) of
+                        ( Just lv, Just bv ) ->
+                            lv == bv
+
+                        _ ->
+                            False
+
                 cmd =
                     if sameRelease then
                         UcmCommand.Install project.ref Nothing


### PR DESCRIPTION
## Problem

Trying to install a library with no release gives:

    scratch/main> lib.install @staccatosemibreve/optics

    @staccatosemibreve/optics has no releases.

So we need to make sure there's a release at all! Otherwise we need to include the branch name.

![image](https://github.com/user-attachments/assets/65d48a9b-82e2-4e22-a9c8-08ec96c8833b)

![image](https://github.com/user-attachments/assets/46411384-0f15-4ab8-9498-baf4260dd327)

## Solution

Check that there's a release (instead of just comparing Nothing and Nothing).

## Caveats/Notes

Originally I was going with something like:

```
withDefault false (map2 (==) project.latestVersion (BranchRef.version br))
```

But then I noticed other code in this file seemed to prefer pattern matching, so I went with that.