### PR TITLE
Guard against how Browsers encode spaces

### DIFF
--- a/src/UnisonShare/App.elm
+++ b/src/UnisonShare/App.elm
@@ -106,6 +106,11 @@ init appContext route =
                         search =
                             Parser.parse (Parser.query (Query.string "search")) url
                                 |> Maybe.withDefault Nothing
+                                -- When using the Browser's address bar to
+                                -- perform a search on Share it uses + instead
+                                -- of %20 to encode spaces and this ends up as
+                                -- literal + when parsed with Url.percentDecode
+                                |> Maybe.map (String.replace "+" "%20")
                                 |> Maybe.andThen Url.percentDecode
 
                         filter =


### PR DESCRIPTION
When using the Browser's address bar to perform a search on Share it uses `+` instead of `%20` to encode spaces and this ends up as literal `+` when parsed with `Url.percentDecode`. To solve this, replace all `+` with `%20%` before calling `Url.percentDecode`.

Note: this will still work for search queries where the user wants to find "+", which is encoded by `Url.percentEncode` as `%2b`.

Fixes https://github.com/unisoncomputing/share-ui/issues/34