### PR TITLE
Add OrgProfilePage

### DIFF
--- a/src/UnisonShare/Org.elm
+++ b/src/UnisonShare/Org.elm
@@ -1,0 +1,60 @@
+module UnisonShare.Org exposing
+    ( Org
+    , OrgSummary
+    , decodeSummary
+    , name
+    , toAvatar
+    )
+
+import Json.Decode as Decode exposing (field, maybe, string)
+import Lib.UserHandle as UserHandle exposing (UserHandle)
+import Lib.Util exposing (decodeUrl)
+import UI.Avatar as Avatar exposing (Avatar)
+import UI.Icon as Icon
+import Url exposing (Url)
+
+
+type alias Org u =
+    { u
+        | handle : UserHandle
+        , name : Maybe String
+        , avatarUrl : Maybe Url
+    }
+
+
+type alias OrgSummary =
+    Org {}
+
+
+
+-- HELPERS
+
+
+name : Org u -> String
+name user =
+    Maybe.withDefault (UserHandle.toString user.handle) user.name
+
+
+toAvatar : Org u -> Avatar msg
+toAvatar user =
+    Avatar.avatar user.avatarUrl (Just (name user))
+        |> Avatar.withIcon Icon.user
+
+
+
+-- DECODE
+
+
+decodeSummary : Decode.Decoder OrgSummary
+decodeSummary =
+    let
+        makeSummary handle name_ avatarUrl =
+            { handle = handle
+            , name = name_
+            , avatarUrl = avatarUrl
+            }
+    in
+    Decode.map3 makeSummary
+        (field "handle" UserHandle.decodeUnprefixed)
+        (maybe (field "name" string))
+        (maybe (field "avatarUrl" decodeUrl))

--- a/src/UnisonShare/OrgPageHeader.elm
+++ b/src/UnisonShare/OrgPageHeader.elm
@@ -1,0 +1,55 @@
+module UnisonShare.OrgPageHeader exposing (..)
+
+import Lib.UserHandle exposing (UserHandle)
+import UI.PageHeader as PageHeader exposing (PageHeader)
+import UI.ProfileSnippet as ProfileSnippet
+import UnisonShare.Link as Link
+import UnisonShare.Org exposing (Org)
+
+
+type ActiveNavItem
+    = OrgProfile
+    | People
+    | Settings
+
+
+
+-- CREATE
+
+
+empty : PageHeader msg
+empty =
+    let
+        context =
+            { isActive = False
+            , click = Nothing
+            , content = ProfileSnippet.loading |> ProfileSnippet.view
+            }
+    in
+    PageHeader.pageHeader context
+
+
+loading : PageHeader msg
+loading =
+    empty
+
+
+error : PageHeader msg
+error =
+    empty
+
+
+view : msg -> Bool -> ActiveNavItem -> UserHandle -> Org o -> PageHeader msg
+view _ _ activeNavItem handle org =
+    let
+        context_ =
+            ProfileSnippet.profileSnippet org |> ProfileSnippet.view
+
+        context =
+            { isActive = activeNavItem == OrgProfile
+            , click = Just (Link.userProfile handle)
+            , content = context_
+            }
+    in
+    context
+        |> PageHeader.pageHeader

--- a/src/UnisonShare/Page/OrgPage.elm
+++ b/src/UnisonShare/Page/OrgPage.elm
@@ -1,0 +1,162 @@
+module UnisonShare.Page.OrgPage exposing (..)
+
+import Html exposing (h2, text)
+import Http
+import Lib.HttpApi as HttpApi
+import Lib.UserHandle as UserHandle exposing (UserHandle)
+import RemoteData exposing (RemoteData(..), WebData)
+import UI.EmptyState as EmptyState
+import UI.EmptyStateCard as EmptyStateCard
+import UI.Icon as Icon
+import UI.PageContent as PageContent
+import UI.PageLayout as PageLayout
+import UI.StatusMessage as StatusMessage
+import UnisonShare.Api as ShareApi
+import UnisonShare.AppContext exposing (AppContext)
+import UnisonShare.AppDocument exposing (AppDocument)
+import UnisonShare.AppHeader as AppHeader
+import UnisonShare.Org as Org exposing (OrgSummary)
+import UnisonShare.OrgPageHeader as OrgPageHeader
+import UnisonShare.PageFooter as PageFooter
+import UnisonShare.Route exposing (OrgRoute)
+
+
+
+-- MODEL
+
+
+type SubPage
+    = People
+    | Settings
+
+
+type alias Model =
+    { org : WebData OrgSummary
+    , subPage : SubPage
+    , mobileNavIsOpen : Bool
+    }
+
+
+init : AppContext -> UserHandle -> OrgRoute -> ( Model, Cmd Msg )
+init appContext handle _ =
+    ( { org = Loading
+      , subPage = People
+      , mobileNavIsOpen = False
+      }
+    , fetchOrg appContext handle
+    )
+
+
+
+-- UPDATE
+
+
+type Msg
+    = FetchOrgFinished (WebData OrgSummary)
+    | ToggleMobileNav
+
+
+update : AppContext -> UserHandle -> OrgRoute -> Msg -> Model -> ( Model, Cmd Msg )
+update _ _ _ msg model =
+    case ( model.subPage, msg ) of
+        ( _, FetchOrgFinished o ) ->
+            ( { model | org = o }, Cmd.none )
+
+        ( _, ToggleMobileNav ) ->
+            ( { model | mobileNavIsOpen = not model.mobileNavIsOpen }, Cmd.none )
+
+
+updateSubPage : AppContext -> UserHandle -> Model -> OrgRoute -> ( Model, Cmd Msg )
+updateSubPage _ _ model _ =
+    ( model, Cmd.none )
+
+
+
+-- EFFECTS
+
+
+fetchOrg : AppContext -> UserHandle -> Cmd Msg
+fetchOrg appContext handle =
+    ShareApi.user handle
+        |> HttpApi.toRequest Org.decodeSummary (RemoteData.fromResult >> FetchOrgFinished)
+        |> HttpApi.perform appContext.api
+
+
+
+-- VIEW
+
+
+viewErrorPage : AppContext -> SubPage -> UserHandle -> Http.Error -> AppDocument msg
+viewErrorPage _ subPage handle error =
+    let
+        page =
+            case ( error, subPage ) of
+                ( Http.BadStatus 404, _ ) ->
+                    PageLayout.centeredLayout
+                        (PageContent.oneColumn
+                            [ EmptyState.iconCloud
+                                (EmptyState.IconCenterPiece Icon.profile)
+                                |> EmptyState.withContent [ h2 [] [ text ("Couldn't find organization " ++ UserHandle.toString handle) ] ]
+                                |> EmptyStateCard.view
+                            ]
+                        )
+                        PageFooter.pageFooter
+                        |> PageLayout.withSubduedBackground
+
+                _ ->
+                    PageLayout.centeredLayout
+                        (PageContent.oneColumn [ StatusMessage.bad "Error, could not load page" [] |> StatusMessage.view ])
+                        PageFooter.pageFooter
+                        |> PageLayout.withSubduedBackground
+    in
+    { pageId = "org-page org-page-error"
+    , title = UserHandle.toString handle ++ " | Error"
+    , appHeader = AppHeader.appHeader AppHeader.None
+    , pageHeader = Just OrgPageHeader.error
+    , page = PageLayout.view page
+    , modal = Nothing
+    }
+
+
+viewLoadingPage : AppContext -> SubPage -> UserHandle -> AppDocument msg
+viewLoadingPage _ _ handle =
+    { pageId = "org-page org-page_loading "
+    , title = UserHandle.toString handle ++ " | Loading..."
+    , appHeader = AppHeader.appHeader AppHeader.None
+    , pageHeader = Just OrgPageHeader.loading
+    , page =
+        PageLayout.centeredNarrowLayout (PageContent.oneColumn [ text "loading..." ])
+            PageFooter.pageFooter
+            |> PageLayout.view
+    , modal = Nothing
+    }
+
+
+view : AppContext -> UserHandle -> Model -> AppDocument Msg
+view appContext handle model =
+    {-
+       let
+           handle_ =
+               UserHandle.toString handle
+
+           orgPageHeader activeNavItem user =
+               OrgPageHeader.view
+                   ToggleMobileNav
+                   model.mobileNavIsOpen
+                   activeNavItem
+                   handle
+                   user
+       in
+    -}
+    case model.org of
+        NotAsked ->
+            viewLoadingPage appContext model.subPage handle
+
+        Loading ->
+            viewLoadingPage appContext model.subPage handle
+
+        Failure e ->
+            viewErrorPage appContext model.subPage handle e
+
+        Success _ ->
+            viewLoadingPage appContext model.subPage handle

--- a/src/UnisonShare/Page/OrgProfilePage.elm
+++ b/src/UnisonShare/Page/OrgProfilePage.elm
@@ -1,0 +1,186 @@
+module UnisonShare.Page.OrgProfilePage exposing (..)
+
+import Html exposing (Html, div, text)
+import Html.Attributes exposing (class)
+import Http
+import Json.Decode as Decode
+import Lib.HttpApi as HttpApi
+import Lib.UserHandle exposing (UserHandle)
+import Maybe.Extra as MaybeE
+import RemoteData exposing (RemoteData(..), WebData)
+import Set
+import UI
+import UI.Card as Card
+import UI.Divider as Divider
+import UI.PageContent as PageContent exposing (PageContent)
+import UI.PageLayout as PageLayout
+import UI.PageTitle as PageTitle
+import UI.ProfileSnippet as ProfileSnippet
+import UI.Tag as Tag
+import UnisonShare.Api as ShareApi
+import UnisonShare.AppContext exposing (AppContext)
+import UnisonShare.Link as Link
+import UnisonShare.Org exposing (OrgSummary)
+import UnisonShare.PageFooter as PageFooter
+import UnisonShare.Project as Project exposing (ProjectSummary)
+import UnisonShare.Project.ProjectListing as ProjectListing
+
+
+
+-- MODEL
+
+
+type alias ProfileFormFields =
+    { bio : String }
+
+
+type ProfileForm
+    = Editing ProfileFormFields
+    | Saving ProfileFormFields
+      -- Success isn't tracked, we just close the modal.
+    | SaveFailed ProfileFormFields Http.Error
+
+
+type UserProfileModal
+    = NoModal
+    | EditProfileModal ProfileForm
+
+
+type alias Model =
+    { projects : WebData (List ProjectSummary)
+    , modal : UserProfileModal
+    }
+
+
+init : AppContext -> UserHandle -> ( Model, Cmd Msg )
+init appContext handle =
+    ( { projects = Loading, modal = NoModal }
+    , fetchProjects appContext handle
+    )
+
+
+
+-- UPDATE
+
+
+type Msg
+    = NoOp
+    | FetchProjectsFinished (WebData (List ProjectSummary))
+    | CloseModal
+
+
+update : AppContext -> UserHandle -> OrgSummary -> Msg -> Model -> ( Model, Cmd Msg )
+update _ _ _ msg model =
+    case msg of
+        NoOp ->
+            ( model, Cmd.none )
+
+        FetchProjectsFinished projects ->
+            ( { model | projects = projects }, Cmd.none )
+
+        CloseModal ->
+            ( { model | modal = NoModal }, Cmd.none )
+
+
+
+-- EFFECTS
+
+
+fetchProjects : AppContext -> UserHandle -> Cmd Msg
+fetchProjects appContext handle =
+    ShareApi.userProjects handle
+        |> HttpApi.toRequest
+            (Decode.list Project.decodeSummary)
+            (RemoteData.fromResult >> FetchProjectsFinished)
+        |> HttpApi.perform appContext.api
+
+
+
+-- VIEW
+
+
+viewProjects : List ProjectSummary -> Html msg
+viewProjects projects_ =
+    case projects_ of
+        [] ->
+            UI.nothing
+
+        projects ->
+            let
+                viewProject p =
+                    let
+                        tags =
+                            case Set.toList p.tags of
+                                [] ->
+                                    UI.nothing
+
+                                ts ->
+                                    ts |> List.map Tag.tag |> Tag.viewTags
+                    in
+                    div [ class "project" ]
+                        [ p
+                            |> ProjectListing.projectListing
+                            |> ProjectListing.withClick Link.userProfile Link.projectOverview
+                            |> ProjectListing.view
+                        , MaybeE.unwrap UI.nothing (\s -> div [ class "project-summary" ] [ text s ]) p.summary
+                        , tags
+                        ]
+
+                card_ =
+                    Card.titled
+                        "Projects"
+                        [ div [ class "projects" ]
+                            (List.intersperse (Divider.divider |> Divider.small |> Divider.view)
+                                (List.map viewProject projects)
+                            )
+                        ]
+                        |> Card.asContained
+            in
+            Card.view card_
+
+
+view_ :
+    OrgSummary
+    -> WebData (List ProjectSummary)
+    -> PageContent Msg
+view_ org projects =
+    let
+        pageContent =
+            [ projects
+                |> RemoteData.map viewProjects
+                |> RemoteData.withDefault UI.nothing
+            ]
+
+        pageTitle =
+            PageTitle.custom
+                [ ProfileSnippet.profileSnippet
+                    org
+                    |> ProfileSnippet.huge
+                    |> ProfileSnippet.view
+                ]
+    in
+    PageContent.oneColumn pageContent
+        |> PageContent.withPageTitle pageTitle
+
+
+viewLoadingPage : PageLayout.PageLayout msg
+viewLoadingPage =
+    let
+        content =
+            PageContent.oneColumn
+                [ div [ class "org-profile-page_page-content" ]
+                    [ div [ class "org-profile_main-content" ]
+                        [ text "Loading..." ]
+                    ]
+                ]
+    in
+    PageLayout.centeredNarrowLayout content PageFooter.pageFooter
+        |> PageLayout.withSubduedBackground
+
+
+view : OrgSummary -> Model -> PageLayout.PageLayout Msg
+view org model =
+    PageLayout.centeredNarrowLayout
+        (view_ org model.projects)
+        PageFooter.pageFooter
+        |> PageLayout.withSubduedBackground

--- a/src/UnisonShare/Page/ProfilePage.elm
+++ b/src/UnisonShare/Page/ProfilePage.elm
@@ -1,0 +1,267 @@
+-- Users and Orgs profiles share a URL space, this module conditionally render
+-- one or the other.
+
+
+module UnisonShare.Page.ProfilePage exposing (..)
+
+import Html exposing (div, text)
+import Html.Attributes exposing (class)
+import Http
+import Json.Decode as Decode
+import Json.Decode.Extra exposing (when)
+import Lib.HttpApi as HttpApi exposing (HttpResult)
+import Lib.UserHandle as UserHandle exposing (UserHandle)
+import Lib.Util as Util
+import UI.PageContent as PageContent
+import UI.PageLayout as PageLayout
+import UI.StatusMessage as StatusMessage
+import UnisonShare.Api as ShareApi
+import UnisonShare.AppContext exposing (AppContext)
+import UnisonShare.AppDocument exposing (AppDocument)
+import UnisonShare.AppHeader as AppHeader
+import UnisonShare.Org as Org exposing (OrgSummary)
+import UnisonShare.OrgPageHeader as OrgPageHeader
+import UnisonShare.Page.OrgProfilePage as OrgProfilePage
+import UnisonShare.Page.UserProfilePage as UserProfilePage
+import UnisonShare.PageFooter as PageFooter
+import UnisonShare.User as User exposing (UserDetails)
+import UnisonShare.UserPageHeader as UserPageHeader
+
+
+
+-- MODEL
+
+
+type Profile
+    = User UserDetails
+    | Org OrgSummary
+
+
+type Model
+    = Loading UserHandle
+    | UserProfile
+        { user : UserDetails
+        , page : UserProfilePage.Model
+        , mobileNavIsOpen : Bool
+        }
+    | OrgProfile
+        { org : OrgSummary
+        , page : OrgProfilePage.Model
+        , mobileNavIsOpen : Bool
+        }
+    | Failure UserHandle Http.Error
+
+
+init : AppContext -> UserHandle -> ( Model, Cmd Msg )
+init appContext handle =
+    ( Loading handle, fetchProfile appContext handle )
+
+
+
+-- UPDATE
+
+
+type Msg
+    = FetchProfileFinished (HttpResult Profile)
+    | ToggleMobileNav
+    | UserProfilePageMsg UserProfilePage.Msg
+    | OrgProfilePageMsg OrgProfilePage.Msg
+
+
+update : AppContext -> UserHandle -> Msg -> Model -> ( Model, Cmd Msg )
+update appContext handle msg model =
+    case msg of
+        FetchProfileFinished (Ok (User u)) ->
+            let
+                ( page, pageCmd ) =
+                    UserProfilePage.init appContext handle
+            in
+            ( UserProfile { user = u, page = page, mobileNavIsOpen = False }
+            , Cmd.map UserProfilePageMsg pageCmd
+            )
+
+        FetchProfileFinished (Ok (Org o)) ->
+            let
+                ( page, pageCmd ) =
+                    OrgProfilePage.init appContext handle
+            in
+            ( OrgProfile { org = o, page = page, mobileNavIsOpen = False }
+            , Cmd.map OrgProfilePageMsg pageCmd
+            )
+
+        FetchProfileFinished (Err e) ->
+            ( Failure handle e, Cmd.none )
+
+        ToggleMobileNav ->
+            case model of
+                UserProfile p ->
+                    ( UserProfile { p | mobileNavIsOpen = not p.mobileNavIsOpen }, Cmd.none )
+
+                OrgProfile p ->
+                    ( OrgProfile { p | mobileNavIsOpen = not p.mobileNavIsOpen }, Cmd.none )
+
+                _ ->
+                    ( model, Cmd.none )
+
+        UserProfilePageMsg userProfilePageMsg ->
+            case model of
+                UserProfile p ->
+                    let
+                        ( profilePage_, profileCmd, out ) =
+                            UserProfilePage.update appContext handle p.user userProfilePageMsg p.page
+
+                        user =
+                            case out of
+                                UserProfilePage.NoOut ->
+                                    p.user
+
+                                UserProfilePage.UpdateUserProfile u ->
+                                    u
+                    in
+                    ( UserProfile { p | page = profilePage_, user = user }, Cmd.map UserProfilePageMsg profileCmd )
+
+                _ ->
+                    ( model, Cmd.none )
+
+        OrgProfilePageMsg orgProfilePageMsg ->
+            case model of
+                OrgProfile p ->
+                    let
+                        ( profilePage_, profileCmd ) =
+                            OrgProfilePage.update appContext handle p.org orgProfilePageMsg p.page
+                    in
+                    ( OrgProfile { p | page = profilePage_ }, Cmd.map OrgProfilePageMsg profileCmd )
+
+                _ ->
+                    ( model, Cmd.none )
+
+
+
+-- EFFECTS
+
+
+fetchProfile : AppContext -> UserHandle -> Cmd Msg
+fetchProfile appContext handle =
+    let
+        decode =
+            Decode.oneOf
+                [ when (Decode.field "kind" Decode.string) ((==) "org") (Decode.map Org Org.decodeSummary)
+                , when (Decode.field "kind" Decode.string) ((==) "user") (Decode.map User User.decodeDetails)
+                ]
+    in
+    ShareApi.user handle
+        |> HttpApi.toRequest decode FetchProfileFinished
+        |> HttpApi.perform appContext.api
+
+
+viewLoadingPage : PageLayout.PageLayout msg
+viewLoadingPage =
+    let
+        content =
+            PageContent.oneColumn
+                [ div [ class "profile-page_page-content" ]
+                    [ div [ class "profile_main-content" ]
+                        [ text "Loading profile..." ]
+                    ]
+                ]
+    in
+    PageLayout.centeredNarrowLayout content PageFooter.pageFooter
+        |> PageLayout.withSubduedBackground
+
+
+viewErrorPage : UserHandle -> Http.Error -> AppDocument msg
+viewErrorPage handle error =
+    let
+        page =
+            case error of
+                Http.BadStatus 404 ->
+                    PageLayout.centeredNarrowLayout
+                        (PageContent.oneColumn [ StatusMessage.bad "Error, page not found" [] |> StatusMessage.view ])
+                        PageFooter.pageFooter
+
+                _ ->
+                    PageLayout.centeredNarrowLayout
+                        (PageContent.oneColumn
+                            [ StatusMessage.bad "Error, could not load page" [] |> StatusMessage.view
+                            , text (Util.httpErrorToString error)
+                            ]
+                        )
+                        PageFooter.pageFooter
+                        |> PageLayout.withSubduedBackground
+    in
+    { pageId = "profile-page profile-page-error"
+    , title = UserHandle.toString handle ++ " | Error"
+    , appHeader = AppHeader.appHeader AppHeader.None
+    , pageHeader = Nothing
+    , page = PageLayout.view page
+    , modal = Nothing
+    }
+
+
+view : AppContext -> Model -> AppDocument Msg
+view appContext model =
+    let
+        appDoc pageId pageHeader pageTitle page modal =
+            { pageId = pageId
+            , title = pageTitle
+            , appHeader = AppHeader.appHeader AppHeader.None
+            , pageHeader = pageHeader
+            , page = PageLayout.view page
+            , modal = modal
+            }
+    in
+    case model of
+        Loading handle ->
+            appDoc
+                "user-or-org-profile-page"
+                Nothing
+                (UserHandle.toString handle)
+                viewLoadingPage
+                Nothing
+
+        UserProfile { user, page, mobileNavIsOpen } ->
+            let
+                ( page_, modal_ ) =
+                    UserProfilePage.view appContext.session user page
+
+                header =
+                    Just
+                        (UserPageHeader.view
+                            ToggleMobileNav
+                            mobileNavIsOpen
+                            UserPageHeader.UserProfile
+                            user.handle
+                            user
+                        )
+            in
+            appDoc
+                "user-page user-profile-page"
+                header
+                (UserHandle.toString user.handle)
+                (PageLayout.map UserProfilePageMsg page_)
+                (Maybe.map (Html.map UserProfilePageMsg) modal_)
+
+        OrgProfile { org, page, mobileNavIsOpen } ->
+            let
+                page_ =
+                    OrgProfilePage.view org page
+
+                header =
+                    Just
+                        (OrgPageHeader.view
+                            ToggleMobileNav
+                            mobileNavIsOpen
+                            OrgPageHeader.OrgProfile
+                            org.handle
+                            org
+                        )
+            in
+            appDoc
+                "org-page org-profile-page"
+                header
+                (UserHandle.toString org.handle)
+                (PageLayout.map OrgProfilePageMsg page_)
+                Nothing
+
+        Failure handle error ->
+            viewErrorPage handle error

--- a/src/UnisonShare/Page/UserPage.elm
+++ b/src/UnisonShare/Page/UserPage.elm
@@ -5,7 +5,6 @@ import Http
 import Lib.HttpApi as HttpApi
 import Lib.UserHandle as UserHandle exposing (UserHandle)
 import RemoteData exposing (RemoteData(..), WebData)
-import Tuple
 import UI.EmptyState as EmptyState
 import UI.EmptyStateCard as EmptyStateCard
 import UI.Icon as Icon
@@ -21,7 +20,6 @@ import UnisonShare.AppHeader as AppHeader
 import UnisonShare.CodeBrowsingContext as CodeBrowsingContext
 import UnisonShare.Page.CodePage as CodePage
 import UnisonShare.Page.UserContributionsPage as UserContributionsPage
-import UnisonShare.Page.UserProfilePage as UserProfilePage
 import UnisonShare.PageFooter as PageFooter
 import UnisonShare.Route as Route exposing (CodeRoute, UserRoute(..))
 import UnisonShare.Session as Session
@@ -34,8 +32,7 @@ import UnisonShare.UserPageHeader as UserPageHeader
 
 
 type SubPage
-    = Profile UserProfilePage.Model
-    | Code CodePage.Model
+    = Code CodePage.Model
     | Contributions UserContributionsPage.Model
 
 
@@ -54,13 +51,6 @@ init appContext handle userRoute =
 
         ( subPage, cmd ) =
             case userRoute of
-                UserProfile ->
-                    let
-                        ( profilePage, profileCmd ) =
-                            UserProfilePage.init appContext handle
-                    in
-                    ( Profile profilePage, Cmd.map UserProfilePageMsg profileCmd )
-
                 UserCode codeRoute ->
                     let
                         ( codePage, codePageCmd ) =
@@ -93,7 +83,6 @@ init appContext handle userRoute =
 type Msg
     = FetchUserFinished (WebData UserDetails)
     | ToggleMobileNav
-    | UserProfilePageMsg UserProfilePage.Msg
     | CodePageMsg CodePage.Msg
     | UserContributionsPageMsg UserContributionsPage.Msg
 
@@ -108,21 +97,6 @@ update appContext handle route msg model =
             ( { model | mobileNavIsOpen = not model.mobileNavIsOpen }, Cmd.none )
 
         -- Sub msgs
-        ( Profile profilePage, UserProfilePageMsg userProfilePageMsg ) ->
-            let
-                ( profilePage_, profileCmd, out ) =
-                    UserProfilePage.update appContext handle model.user userProfilePageMsg profilePage
-
-                user =
-                    case out of
-                        UserProfilePage.NoOut ->
-                            model.user
-
-                        UserProfilePage.UpdateUserProfile u ->
-                            RemoteData.map (\_ -> u) model.user
-            in
-            ( { model | subPage = Profile profilePage_, user = user }, Cmd.map UserProfilePageMsg profileCmd )
-
         ( Code codePage, CodePageMsg codePageMsg ) ->
             let
                 codeBrowsingContext =
@@ -161,18 +135,6 @@ updateSubPage appContext handle model route =
             CodeBrowsingContext.UserCode handle
     in
     case route of
-        UserProfile ->
-            case model.subPage of
-                Profile _ ->
-                    ( model, Cmd.none )
-
-                _ ->
-                    let
-                        ( profilePage, profileCmd ) =
-                            UserProfilePage.init appContext handle
-                    in
-                    ( { model | subPage = Profile profilePage }, Cmd.map UserProfilePageMsg profileCmd )
-
         UserCode codeRoute ->
             case model.subPage of
                 Code codeSubPage ->
@@ -303,9 +265,6 @@ viewLoadingPage appContext subPage handle =
     let
         ( page, pageId ) =
             case subPage of
-                Profile _ ->
-                    ( UserProfilePage.viewLoadingPage, "user-profile-page" )
-
                 Code _ ->
                     ( PageLayout.sidebarLeftContentLayout
                         appContext.operatingSystem
@@ -353,29 +312,6 @@ view appContext handle model =
 
         Success user ->
             case model.subPage of
-                Profile profilePage ->
-                    let
-                        ( page, modal ) =
-                            UserProfilePage.view appContext.session user profilePage
-                                |> Tuple.mapFirst (PageLayout.map UserProfilePageMsg)
-                                |> Tuple.mapFirst PageLayout.view
-                                |> Tuple.mapSecond (Maybe.map (Html.map UserProfilePageMsg))
-
-                        activeNavItem =
-                            if isSignedInUser appContext model then
-                                AppHeader.Profile
-
-                            else
-                                AppHeader.None
-                    in
-                    { pageId = "user-page user-profile-page"
-                    , title = handle_
-                    , appHeader = AppHeader.appHeader activeNavItem
-                    , pageHeader = Just (userProfilePageHeader UserPageHeader.UserProfile user)
-                    , page = page
-                    , modal = modal
-                    }
-
                 Contributions contributionsPage ->
                     { pageId = "user-page user-contributions-page"
                     , title = handle_ ++ " | Contributions"

--- a/src/UnisonShare/Page/UserProfilePage.elm
+++ b/src/UnisonShare/Page/UserProfilePage.elm
@@ -86,7 +86,7 @@ type OutMsg
     | UpdateUserProfile UserDetails
 
 
-update : AppContext -> UserHandle -> WebData UserDetails -> Msg -> Model -> ( Model, Cmd Msg, OutMsg )
+update : AppContext -> UserHandle -> UserDetails -> Msg -> Model -> ( Model, Cmd Msg, OutMsg )
 update appContext handle user msg model =
     case msg of
         NoOp ->
@@ -96,11 +96,11 @@ update appContext handle user msg model =
             ( { model | projects = projects }, Cmd.none, NoOut )
 
         ShowEditProfileModal ->
-            case ( Session.isHandle handle appContext.session, RemoteData.map .bio user ) of
-                ( True, Success (Just b) ) ->
+            case ( Session.isHandle handle appContext.session, user.bio ) of
+                ( True, Just b ) ->
                     ( { model | modal = EditProfileModal (Editing { bio = b }) }, Cmd.none, NoOut )
 
-                ( True, Success Nothing ) ->
+                ( True, Nothing ) ->
                     ( { model | modal = EditProfileModal (Editing { bio = "" }) }, Cmd.none, NoOut )
 
                 _ ->
@@ -130,14 +130,14 @@ update appContext handle user msg model =
                     ( model, Cmd.none, NoOut )
 
         SaveProfileFinished result ->
-            case ( user, model.modal, result ) of
-                ( Success u, EditProfileModal (Saving f), Ok _ ) ->
+            case ( model.modal, result ) of
+                ( EditProfileModal (Saving f), Ok _ ) ->
                     ( { model | modal = NoModal }
                     , Cmd.none
-                    , UpdateUserProfile { u | bio = Just f.bio }
+                    , UpdateUserProfile { user | bio = Just f.bio }
                     )
 
-                ( _, EditProfileModal (Saving f), Err e ) ->
+                ( EditProfileModal (Saving f), Err e ) ->
                     ( { model | modal = EditProfileModal (SaveFailed f e) }
                     , Cmd.none
                     , NoOut

--- a/src/UnisonShare/User.elm
+++ b/src/UnisonShare/User.elm
@@ -41,7 +41,6 @@ type alias UserDetails =
         , location : Maybe String
         , bio : Maybe String
         , pronouns : Maybe String
-        , twitterHandle : Maybe String
         }
 
 
@@ -101,7 +100,7 @@ decodeSummaryWithId =
 decodeDetails : Decode.Decoder UserDetails
 decodeDetails =
     let
-        makeDetails handle name_ avatarUrl pronouns bio location website twitterHandle =
+        makeDetails handle name_ avatarUrl pronouns bio location website =
             { handle = handle
             , name = name_
             , avatarUrl = avatarUrl
@@ -109,7 +108,6 @@ decodeDetails =
             , bio = bio
             , location = location
             , website = website
-            , twitterHandle = twitterHandle
             }
     in
     Decode.succeed makeDetails
@@ -120,4 +118,3 @@ decodeDetails =
         |> required "bio" (nullable string)
         |> required "location" (nullable string)
         |> required "website" (nullable decodeUrl)
-        |> required "twitterHandle" (nullable string)

--- a/src/css/unison-share/page.css
+++ b/src/css/unison-share/page.css
@@ -1,4 +1,5 @@
 @import "./page/catalog-page.css";
+@import "./page/org-profile-page.css";
 @import "./page/user-profile-page.css";
 @import "./page/user-contributions-page.css";
 @import "./page/project-page.css";

--- a/src/css/unison-share/page/org-profile-page.css
+++ b/src/css/unison-share/page/org-profile-page.css
@@ -1,0 +1,39 @@
+.org-profile-page .org-profile_info {
+  display: flex;
+  flex-direction: column;
+}
+
+.org-profile-page .org-profile_main-content {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  flex: 1;
+  flex-grow: 1;
+}
+
+.org-profile-page .projects {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+}
+
+.org-profile-page .project {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.org-profile-page .project .project-summary {
+  font-size: var(--font-size-medium);
+  margin-left: 2rem;
+}
+
+.org-profile-page .project .tags {
+  margin-left: 2rem;
+}
+
+@media only screen and (--u-viewport_max-md) {
+  .org-profile-page .org-profile-page_page-content {
+    flex-direction: column;
+  }
+}

--- a/tests/UnisonShare/RouteTests.elm
+++ b/tests/UnisonShare/RouteTests.elm
@@ -130,17 +130,17 @@ notFound =
 -- USERS ROUTE
 
 
-userProfileRoute : Test
-userProfileRoute =
-    describe "Route.fromUrl : user profile route"
-        [ test "Matches /:handle to UserProfile " <|
+profileRoute : Test
+profileRoute =
+    describe "Route.fromUrl : profile route"
+        [ test "Matches /:handle to Profile " <|
             \_ ->
                 let
                     url =
                         mkUrl "/@unison"
                 in
                 Expect.equal
-                    (User (UserHandle.unsafeFromString "unison") UserProfile)
+                    (Profile (UserHandle.unsafeFromString "unison"))
                     (Route.fromUrl "" url)
         ]
 

--- a/tests/e2e/CatalogPage.spec.ts
+++ b/tests/e2e/CatalogPage.spec.ts
@@ -3,52 +3,9 @@ import * as API from "./TestHelpers/Api";
 
 test("Simulate the Checkly check", async ({ page }) => {
   await API.getAccount(page, "@testuser");
-
-  await page.route("*/**/api/catalog", async (route) => {
-    const json = [
-      {
-        name: "Featured",
-        projects: [
-          {
-            createdAt: "2023-05-25T01:39:01.955533Z",
-            isFaved: true,
-            numFavs: 4,
-            owner: {
-              handle: "@unison",
-              name: "Unison",
-              type: "organization",
-            },
-            slug: "base",
-            summary: "The unison base library.",
-            tags: [],
-            updatedAt: "2023-06-05T02:37:25.346367Z",
-            visibility: "public",
-          },
-          {
-            createdAt: "2023-04-03T17:05:08.873717Z",
-            isFaved: false,
-            numFavs: 5,
-            owner: {
-              handle: "@unison",
-              name: "Unison",
-              type: "organization",
-            },
-            slug: "distributed",
-            summary:
-              "A library for distributed computing. Computations can be run locally or on unison.cloud.",
-            tags: [],
-            updatedAt: "2023-04-05T02:38:23.774294Z",
-            visibility: "public",
-          },
-        ],
-      },
-    ];
-
-    await route.fulfill({ json });
-  });
+  await API.getCatalog(page);
 
   const response = await page.goto("http://localhost:1234/");
-  // Test that the response did not fail
   expect(response?.status()).toBeLessThan(400);
 
   const base = page.getByTitle("@unison/base");

--- a/tests/e2e/ProfilePage.spec.ts
+++ b/tests/e2e/ProfilePage.spec.ts
@@ -1,0 +1,36 @@
+import { test, expect } from "@playwright/test";
+import * as API from "./TestHelpers/Api";
+
+test.beforeEach(async ({ page }) => {
+  await API.getWebsiteFeed(page);
+});
+
+test("can view a user profile", async ({ page }) => {
+  await API.getAccount(page, "@alice");
+  await API.getUserProfile(page, "@bob");
+  await API.getProjects(page, "@bob");
+
+  const response = await page.goto("http://localhost:1234/@bob");
+  expect(response?.status()).toBeLessThan(400);
+
+  const handle = page.locator(".page-header").getByText("@bob");
+  await expect(handle).toBeVisible();
+
+  const projects = page.locator(".project-listing");
+  await expect(projects).toHaveCount(3);
+});
+
+test("can view an org profile", async ({ page }) => {
+  await API.getAccount(page, "@alice");
+  await API.getOrgProfile(page, "@unison");
+  await API.getProjects(page, "@unison");
+
+  const response = await page.goto("http://localhost:1234/@unison");
+  expect(response?.status()).toBeLessThan(400);
+
+  const handle = page.locator(".page-header").getByText("@unison");
+  await expect(handle).toBeVisible();
+
+  const projects = page.locator(".project-listing");
+  await expect(projects).toHaveCount(3);
+});

--- a/tests/e2e/TestHelpers/Api.ts
+++ b/tests/e2e/TestHelpers/Api.ts
@@ -1,6 +1,13 @@
 // Backend API Stubs
 import { Page } from "@playwright/test";
-import { project, contributionTimeline, contribution, account } from "./Data";
+import {
+  project,
+  contributionTimeline,
+  userDetails,
+  org,
+  contribution,
+  account,
+} from "./Data";
 
 async function getWebsiteFeed(page: Page) {
   const data = {
@@ -15,6 +22,51 @@ async function getWebsiteFeed(page: Page) {
   return page.route(`*/**/website/feed.json`, async (request) => {
     await request.fulfill({ status: 200, json: data });
   });
+}
+
+// -- /catalog
+
+async function getCatalog(page: Page) {
+  const data = [
+    {
+      name: "Featured",
+      projects: [
+        {
+          createdAt: "2023-05-25T01:39:01.955533Z",
+          isFaved: true,
+          numFavs: 4,
+          owner: {
+            handle: "@unison",
+            name: "Unison",
+            type: "organization",
+          },
+          slug: "base",
+          summary: "The unison base library.",
+          tags: [],
+          updatedAt: "2023-06-05T02:37:25.346367Z",
+          visibility: "public",
+        },
+        {
+          createdAt: "2023-04-03T17:05:08.873717Z",
+          isFaved: false,
+          numFavs: 5,
+          owner: {
+            handle: "@unison",
+            name: "Unison",
+            type: "organization",
+          },
+          slug: "distributed",
+          summary:
+            "A library for distributed computing. Computations can be run locally or on unison.cloud.",
+          tags: [],
+          updatedAt: "2023-04-05T02:38:23.774294Z",
+          visibility: "public",
+        },
+      ],
+    },
+  ];
+
+  return get(page, { url: "catalog", status: 200, data });
 }
 
 // -- /account
@@ -38,7 +90,33 @@ async function getAccount(
   }
 }
 
-// -- /users/:handle/project
+async function getUserProfile(page: Page, handle: string, userData = {}) {
+  return get(page, {
+    url: `users/${handle.replace("@", "")}`,
+    status: 200,
+    data: { ...userDetails(handle), ...userData },
+  });
+}
+
+async function getOrgProfile(page: Page, handle: string, orgData = {}) {
+  return get(page, {
+    url: `users/${handle.replace("@", "")}`,
+    status: 200,
+    data: { ...org(handle), ...orgData },
+  });
+}
+
+// -- /users/:handle/projects
+//
+async function getProjects(page: Page, handle: string) {
+  return get(page, {
+    url: `/users/${handle.replace("@", "")}/projects`,
+    status: 200,
+    data: [project(), project(), project()],
+  });
+}
+
+// -- /users/:handle/project/:slug
 
 async function getProject(page: Page, projectRef: string, projectData = {}) {
   return getProject_(page, projectRef, { status: 200, data: projectData });
@@ -184,7 +262,11 @@ async function get(page: Page, response: Response) {
 
 export {
   getWebsiteFeed,
+  getCatalog,
   getAccount,
+  getUserProfile,
+  getOrgProfile,
+  getProjects,
   getProject,
   getProject_,
   getProjectReadme,

--- a/tests/e2e/TestHelpers/Data.ts
+++ b/tests/e2e/TestHelpers/Data.ts
@@ -17,9 +17,41 @@ function user(handle?: string) {
 
   return {
     avatarUrl: faker.image.avatar(),
-    handle: handle_,
+    handle: handle_.replace("@", ""),
     name: `${firstName} ${lastName}`,
     userId: faker.string.uuid(),
+    kind: "user",
+  };
+}
+
+function userDetails(handle?: string) {
+  const firstName = faker.person.firstName();
+  const lastName = faker.person.lastName();
+  const handle_ = handle ? handle : faker.lorem.slug(1);
+
+  return {
+    avatarUrl: faker.image.avatar(),
+    handle: handle_.replace("@", ""),
+    name: `${firstName} ${lastName}`,
+    userId: faker.string.uuid(),
+    website: faker.internet.url(),
+    location: null,
+    bio: faker.person.bio(),
+    pronouns: null,
+    kind: "user",
+  };
+}
+
+function org(handle?: string) {
+  const handle_ = handle ? handle : faker.lorem.slug(1);
+
+  return {
+    avatarUrl: faker.image.avatar(),
+    handle: handle_.replace("@", ""),
+    name: faker.company.name(),
+    orgId: faker.string.uuid(),
+    kind: "org",
+    permissions: [],
   };
 }
 
@@ -29,8 +61,9 @@ function projectRef(handle?: string) {
   return `@${handle_}/${slug}`;
 }
 
-function project(projectRef: string) {
-  const [handle, slug] = projectRef.split("/");
+function project(ref?: string) {
+  const ref_ = ref ? ref : projectRef();
+  const [handle, slug] = ref_.split("/");
 
   return {
     createdAt: faker.date.past(),
@@ -125,6 +158,9 @@ export {
   projectRef,
   project,
   account,
+  user,
+  userDetails,
+  org,
   contribution,
   contributionTimeline,
   contributionStatusChangeEvent,


### PR DESCRIPTION
Add a new profile page for organizations that share a URL space with the UserProfilePage.

* Add various underlying org data structures
* Reconfigure the UserPage to no longer deal with UserProfilePage (this is now delegated from a agnostic ProfilePage
* Add ProfilePage that delegates to either UserProfilePage or OrgProfilePage depending on the kind of profile being fetched via the handle
* Add e2e test coverage of the UserProfilePage and OrgProfilePage
* Setup future org routes for /people and /settings