### PR TITLE
Add permissions for adding/removing org members

### DIFF
--- a/src/ConfirmDelete.elm
+++ b/src/ConfirmDelete.elm
@@ -1,0 +1,97 @@
+module ConfirmDelete exposing (..)
+
+import Dict exposing (Dict)
+import Html exposing (Html, div, text)
+import Html.Attributes exposing (class)
+import Http
+import UI.Button as Button
+import UI.Icon as Icon
+import UI.StatusBanner as StatusBanner
+
+
+type ConfirmDelete
+    = Confirm
+    | Deleting
+    | Deleted
+    | DeleteFailed Http.Error
+
+
+type alias ConfirmDeletes =
+    Dict String ConfirmDelete
+
+
+type alias ViewConfig msg =
+    { confirmMsg : msg, cancelMsg : msg }
+
+
+confirm : ConfirmDelete
+confirm =
+    Confirm
+
+
+deleting : ConfirmDelete
+deleting =
+    Deleting
+
+
+deleted : ConfirmDelete
+deleted =
+    Deleted
+
+
+deleteFailed : Http.Error -> ConfirmDelete
+deleteFailed e =
+    DeleteFailed e
+
+
+emptyDeletes : ConfirmDeletes
+emptyDeletes =
+    Dict.empty
+
+
+get : String -> ConfirmDeletes -> Maybe ConfirmDelete
+get key deletes =
+    Dict.get key deletes
+
+
+set : String -> ConfirmDelete -> ConfirmDeletes -> ConfirmDeletes
+set key delete deletes =
+    Dict.insert key delete deletes
+
+
+remove : String -> ConfirmDeletes -> ConfirmDeletes
+remove key deletes =
+    Dict.remove key deletes
+
+
+update : String -> (Maybe ConfirmDelete -> Maybe ConfirmDelete) -> ConfirmDeletes -> ConfirmDeletes
+update key f deletes =
+    Dict.update key f deletes
+
+
+view : ViewConfig msg -> ConfirmDelete -> Html msg
+view { confirmMsg, cancelMsg } confirmDelete =
+    let
+        view_ content =
+            div [ class "confirm-delete" ] content
+    in
+    case confirmDelete of
+        Confirm ->
+            view_
+                [ text "Are you sure?"
+                , Button.iconThenLabel confirmMsg Icon.trash "Yes, delete" |> Button.critical |> Button.small |> Button.view
+                , Button.button cancelMsg "Cancel" |> Button.subdued |> Button.small |> Button.view
+                ]
+
+        Deleting ->
+            view_ [ StatusBanner.working "Deleting..." ]
+
+        Deleted ->
+            view_ [ StatusBanner.good "Deleted" ]
+
+        DeleteFailed _ ->
+            view_
+                [ StatusBanner.bad "Failed to delete"
+                , Button.iconThenLabel confirmMsg Icon.trash "Try again" |> Button.critical |> Button.small |> Button.view
+                , Button.button cancelMsg "Cancel" |> Button.subdued |> Button.small |> Button.view
+                ]

--- a/src/UnisonShare/Link.elm
+++ b/src/UnisonShare/Link.elm
@@ -170,6 +170,21 @@ account =
     toClick Route.account
 
 
+orgProfile : UserHandle -> Click msg
+orgProfile =
+    Route.orgProfile >> toClick
+
+
+orgPeople : UserHandle -> Click msg
+orgPeople =
+    Route.orgPeople >> toClick
+
+
+orgSettings : UserHandle -> Click msg
+orgSettings =
+    Route.orgSettings >> toClick
+
+
 userProfile : UserHandle -> Click msg
 userProfile =
     Route.userProfile >> toClick

--- a/src/UnisonShare/Org.elm
+++ b/src/UnisonShare/Org.elm
@@ -1,6 +1,14 @@
 module UnisonShare.Org exposing
     ( Org
     , OrgSummary
+    , OrgWithPermissions
+    , can
+    , canAdmin
+    , canChangeOwner
+    , canCreateProject
+    , canDelete
+    , canManage
+    , canView
     , decodeSummary
     , name
     , toAvatar
@@ -11,6 +19,7 @@ import Lib.UserHandle as UserHandle exposing (UserHandle)
 import Lib.Util exposing (decodeUrl)
 import UI.Avatar as Avatar exposing (Avatar)
 import UI.Icon as Icon
+import UnisonShare.OrgPermission as OrgPermission exposing (OrgPermission)
 import Url exposing (Url)
 
 
@@ -23,7 +32,7 @@ type alias Org u =
 
 
 type alias OrgSummary =
-    Org {}
+    Org { permissions : List OrgPermission }
 
 
 
@@ -42,19 +51,64 @@ toAvatar user =
 
 
 
+-- PERMISSIONS
+
+
+type alias OrgWithPermissions o =
+    Org { o | permissions : List OrgPermission }
+
+
+can : OrgPermission -> OrgWithPermissions a -> Bool
+can permission org =
+    List.member permission org.permissions
+
+
+canView : OrgWithPermissions a -> Bool
+canView org =
+    can OrgPermission.OrgView org
+
+
+canManage : OrgWithPermissions a -> Bool
+canManage org =
+    can OrgPermission.OrgManage org
+
+
+canAdmin : OrgWithPermissions a -> Bool
+canAdmin org =
+    can OrgPermission.OrgAdmin org
+
+
+canCreateProject : OrgWithPermissions a -> Bool
+canCreateProject org =
+    can OrgPermission.OrgCreateProject org
+
+
+canDelete : OrgWithPermissions a -> Bool
+canDelete org =
+    can OrgPermission.OrgDelete org
+
+
+canChangeOwner : OrgWithPermissions a -> Bool
+canChangeOwner org =
+    can OrgPermission.OrgChangeOwner org
+
+
+
 -- DECODE
 
 
 decodeSummary : Decode.Decoder OrgSummary
 decodeSummary =
     let
-        makeSummary handle name_ avatarUrl =
+        makeSummary handle name_ avatarUrl permissions =
             { handle = handle
             , name = name_
             , avatarUrl = avatarUrl
+            , permissions = permissions
             }
     in
-    Decode.map3 makeSummary
+    Decode.map4 makeSummary
         (field "handle" UserHandle.decodeUnprefixed)
         (maybe (field "name" string))
         (maybe (field "avatarUrl" decodeUrl))
+        (field "permissions" OrgPermission.decodeList)

--- a/src/UnisonShare/OrgPermission.elm
+++ b/src/UnisonShare/OrgPermission.elm
@@ -1,0 +1,57 @@
+module UnisonShare.OrgPermission exposing (..)
+
+import Json.Decode as Decode
+import Lib.Util as Util
+
+
+type OrgPermission
+    = OrgView
+    | OrgManage
+    | OrgAdmin
+    | OrgCreateProject
+    | OrgDelete
+    | OrgChangeOwner
+
+
+fromString : String -> Maybe OrgPermission
+fromString raw =
+    case raw of
+        "org:view" ->
+            Just OrgView
+
+        "org:manage" ->
+            Just OrgManage
+
+        "org:admin" ->
+            Just OrgAdmin
+
+        "org:create_project" ->
+            Just OrgCreateProject
+
+        "org:delete" ->
+            Just OrgDelete
+
+        "org:change_owner" ->
+            Just OrgChangeOwner
+
+        _ ->
+            Nothing
+
+
+decode : Decode.Decoder OrgPermission
+decode =
+    decodeMaybe
+        |> Decode.andThen (Util.decodeFailInvalid "Invalid OrgPermission")
+
+
+decodeMaybe : Decode.Decoder (Maybe OrgPermission)
+decodeMaybe =
+    Decode.map fromString Decode.string
+
+
+{-| soft fail when encountering unknown permissions
+-}
+decodeList : Decode.Decoder (List OrgPermission)
+decodeList =
+    Decode.list decodeMaybe
+        |> Decode.map (List.filterMap identity)

--- a/src/css/confirm-delete.css
+++ b/src/css/confirm-delete.css
@@ -1,0 +1,7 @@
+.confirm-delete {
+  display: flex;
+  flex-direction: row;
+  gap: 0.25rem;
+  font-size: var(--font-size-small);
+  align-items: center;
+}

--- a/src/css/unison-share.css
+++ b/src/css/unison-share.css
@@ -1,3 +1,4 @@
+@import "./confirm-delete.css";
 @import "./unison-share/app.css";
 @import "./unison-share/info-modal.css";
 @import "./unison-share/welcome-tour-modal.css";

--- a/src/css/unison-share/page/org-people-page.css
+++ b/src/css/unison-share/page/org-people-page.css
@@ -8,7 +8,7 @@
 .org-people-page .members_list {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.75rem;
   width: 100%;
 }
 
@@ -20,8 +20,15 @@
 }
 
 .org-people-page .member_role,
-.org-people-page .member_profile-snippet {
+.org-people-page .member_profile-snippet,
+.org-people-page .member_remove {
   width: 33%;
+}
+
+.org-people-page .member_remove {
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
 }
 
 .org-people-page .member_role {

--- a/tests/UnisonShare/OrgPermissionTests.elm
+++ b/tests/UnisonShare/OrgPermissionTests.elm
@@ -1,0 +1,40 @@
+module UnisonShare.OrgPermissionTests exposing (..)
+
+import Expect
+import Json.Decode as Decode
+import Test exposing (..)
+import UnisonShare.OrgPermission as OrgPermission exposing (OrgPermission(..))
+
+
+decodeList : Test
+decodeList =
+    describe "OrgPermission.decodeList"
+        [ test "Can parse known permissions" <|
+            \_ ->
+                let
+                    result =
+                        Decode.decodeString OrgPermission.decodeList allPermissionsJson
+                in
+                Expect.equal (Ok [ OrgView, OrgManage, OrgAdmin, OrgCreateProject, OrgDelete, OrgChangeOwner ]) result
+        , test "Unknown permissions are ignored" <|
+            \_ ->
+                let
+                    result =
+                        Decode.decodeString OrgPermission.decodeList permissionsWithUnknownsJson
+                in
+                Expect.equal (Ok [ OrgView, OrgManage ]) result
+        ]
+
+
+allPermissionsJson : String
+allPermissionsJson =
+    """
+  ["org:view", "org:manage", "org:admin", "org:create_project", "org:delete", "org:change_owner"]
+  """
+
+
+permissionsWithUnknownsJson : String
+permissionsWithUnknownsJson =
+    """
+  ["org:view", "org:unknown", "org:unknown2", "org:manage"]
+  """


### PR DESCRIPTION
Make sure users can be added to the new org people page based on the current users permissions on that org. Also prevent the owner from being deleted as well as the last user in the org.

Add a new Confirmation UI to give pause to member deletion.