### PR TITLE
Parse new `isSuperAdmin` on session

### DIFF
--- a/src/UnisonShare/Account.elm
+++ b/src/UnisonShare/Account.elm
@@ -19,6 +19,7 @@ type alias Account a =
         , pronouns : Maybe String
         , completedTours : List Tour
         , organizationMemberships : List OrganizationMembership
+        , isSuperAdmin : Bool
     }
 
 
@@ -88,18 +89,20 @@ isProjectOwner projectRef account =
 decodeSummary : Decode.Decoder AccountSummary
 decodeSummary =
     let
-        makeSummary handle name_ avatarUrl completedTours organizationMemberships =
+        makeSummary handle name_ avatarUrl completedTours organizationMemberships isSuperAdmin =
             { handle = handle
             , name = name_
             , avatarUrl = avatarUrl
             , pronouns = Nothing
             , completedTours = Maybe.withDefault [] completedTours
             , organizationMemberships = organizationMemberships
+            , isSuperAdmin = isSuperAdmin
             }
     in
-    Decode.map5 makeSummary
+    Decode.map6 makeSummary
         (field "handle" UserHandle.decodeUnprefixed)
         (maybe (field "name" string))
         (maybe (field "avatarUrl" decodeUrl))
         (maybe (field "completedTours" (Decode.list Tour.decode)))
         (field "organizationMemberships" (Decode.list (Decode.map OrganizationMembership UserHandle.decodeUnprefixed)))
+        (field "isSuperadmin" Decode.bool)

--- a/src/UnisonShare/Page/ErrorPage.elm
+++ b/src/UnisonShare/Page/ErrorPage.elm
@@ -17,7 +17,7 @@ view : Session -> Http.Error -> String -> String -> PageLayout msg
 view session error entityName className =
     let
         errorDetails =
-            if Session.isUnisonMember session then
+            if Session.isSuperAdmin session then
                 details [] [ summary [] [ text "Error Details" ], div [] [ text (Util.httpErrorToString error) ] ]
 
             else

--- a/src/UnisonShare/Session.elm
+++ b/src/UnisonShare/Session.elm
@@ -7,6 +7,7 @@ module UnisonShare.Session exposing
     , isOrganizationMember
     , isProjectOwner
     , isSignedIn
+    , isSuperAdmin
     , isUnisonMember
     )
 
@@ -39,6 +40,16 @@ isSignedIn session =
 
         SignedIn _ ->
             True
+
+
+isSuperAdmin : Session -> Bool
+isSuperAdmin session =
+    case session of
+        Anonymous ->
+            False
+
+        SignedIn account_ ->
+            account_.isSuperAdmin
 
 
 isProjectOwner : ProjectRef -> Session -> Bool

--- a/tests/e2e/TestHelpers/Data.ts
+++ b/tests/e2e/TestHelpers/Data.ts
@@ -5,6 +5,7 @@ function account(handle: string) {
     ...user(),
     handle,
     completedTours: ["welcome-terms"],
+    isSuperadmin: faker.datatype.boolean(),
     organizationMemberships: [],
     primaryEmail: faker.internet.email(),
   };


### PR DESCRIPTION
Parses the new field on the account endpoint and change error details to only render when users are super admins.