### PR TITLE
Conflicting handle: Add new /finish-signup page

### DIFF
--- a/elm-git.json
+++ b/elm-git.json
@@ -1,7 +1,7 @@
 {
     "git-dependencies": {
         "direct": {
-            "https://github.com/unisonweb/ui-core": "78ba490fac82e43146be5653e5a9be2288ac6ad0"
+            "https://github.com/unisonweb/ui-core": "636546d7313661f63397f9f280d9ab8bf212e976"
         },
         "indirect": {}
     }

--- a/src/UnisonShare/Link.elm
+++ b/src/UnisonShare/Link.elm
@@ -7,7 +7,7 @@ import Code.Perspective as Perspective exposing (Perspective)
 import Code.Version exposing (Version)
 import Html exposing (Html, text)
 import Lib.HttpApi as HttpApi exposing (HttpApi)
-import Lib.UserHandle exposing (UserHandle)
+import Lib.UserHandle as UserHandle exposing (UserHandle)
 import UI.Click as Click exposing (Click)
 import UnisonShare.BranchDiff.ChangeLineId exposing (ChangeLineId)
 import UnisonShare.Contribution.ContributionRef exposing (ContributionRef)
@@ -138,6 +138,19 @@ login api returnTo =
                 |> Url.percentEncode
     in
     Click.externalHref_ Click.Self (HttpApi.baseApiUrl api ++ "login?return_to=" ++ returnTo_)
+
+
+{-| Basically same as `login` (since both signup and login are the same in the oauth world), but includes a new handle set by the user
+-}
+finishSignup : HttpApi -> UserHandle -> Click msg
+finishSignup api handle =
+    let
+        handle_ =
+            handle
+                |> UserHandle.toUnprefixedString
+                |> Url.percentEncode
+    in
+    Click.externalHref_ Click.Self (HttpApi.baseApiUrl api ++ "login?handle=" ++ handle_)
 
 
 logout : HttpApi -> Url -> Click msg

--- a/src/UnisonShare/Page/FinishSignupPage.elm
+++ b/src/UnisonShare/Page/FinishSignupPage.elm
@@ -1,0 +1,264 @@
+module UnisonShare.Page.FinishSignupPage exposing (..)
+
+import Html exposing (br, footer, h1, p, strong, text)
+import Html.Attributes exposing (class)
+import Http
+import Json.Decode as Decode
+import Lib.HttpApi as HttpApi
+import Lib.UserHandle as UserHandle exposing (UserHandle)
+import Lib.Util as Util
+import UI.Button as Button
+import UI.Card as Card
+import UI.Form.TextField as TextField
+import UI.Icon as Icon
+import UI.PageContent as PageContent
+import UI.PageLayout as PageLayout
+import UI.StatusIndicator as StatusIndicator
+import UnisonShare.Api as ShareApi
+import UnisonShare.AppContext exposing (AppContext)
+import UnisonShare.AppDocument exposing (AppDocument)
+import UnisonShare.AppHeader as AppHeader
+import UnisonShare.Link as Link
+import UnisonShare.PageFooter as PageFooter
+
+
+
+-- MODEL
+
+
+type PotentialHandle
+    = Blank
+    | UserEntered String
+    | CheckingAvailability UserHandle
+    | NotAvailable UserHandle
+    | Available UserHandle
+
+
+type alias Model =
+    { potentialHandle : PotentialHandle }
+
+
+init : Model
+init =
+    { potentialHandle = Blank }
+
+
+
+-- UPDATE
+
+
+type Msg
+    = NoOp
+    | UpdateHandle String
+    | CheckHandleAvailability UserHandle
+    | HandleAvailabilityCheckFinished UserHandle Bool
+
+
+update : AppContext -> UserHandle -> Msg -> Model -> ( Model, Cmd Msg )
+update appContext _ msg model =
+    case msg of
+        UpdateHandle handleInput ->
+            let
+                cmd =
+                    handleInput
+                        |> String.replace "@" ""
+                        |> UserHandle.fromUnprefixedString
+                        |> Maybe.map (\h -> Util.delayMsg 250 (CheckHandleAvailability h))
+                        |> Maybe.withDefault Cmd.none
+
+                potentialHandle =
+                    if String.isEmpty handleInput then
+                        Blank
+
+                    else
+                        UserEntered handleInput
+            in
+            ( { model | potentialHandle = potentialHandle }
+            , cmd
+            )
+
+        CheckHandleAvailability handle ->
+            let
+                ( model_, cmd ) =
+                    case model.potentialHandle of
+                        UserEntered rawHandle ->
+                            case (String.replace "@" "" >> UserHandle.fromUnprefixedString) rawHandle of
+                                Just h_ ->
+                                    if UserHandle.equals handle h_ then
+                                        ( { model | potentialHandle = CheckingAvailability h_ }
+                                        , checkHandleAvailability appContext h_
+                                        )
+
+                                    else
+                                        ( model, Cmd.none )
+
+                                Nothing ->
+                                    ( model, Cmd.none )
+
+                        _ ->
+                            ( model, Cmd.none )
+            in
+            ( model_, cmd )
+
+        HandleAvailabilityCheckFinished handle isAvailable ->
+            let
+                potentialHandle =
+                    case model.potentialHandle of
+                        CheckingAvailability handle_ ->
+                            if handle == handle_ then
+                                if isAvailable then
+                                    Available handle_
+
+                                else
+                                    NotAvailable handle_
+
+                            else
+                                model.potentialHandle
+
+                        _ ->
+                            model.potentialHandle
+            in
+            ( { model | potentialHandle = potentialHandle }, Cmd.none )
+
+        NoOp ->
+            ( model, Cmd.none )
+
+
+
+-- EFFECTS
+
+
+checkHandleAvailability : AppContext -> UserHandle -> Cmd Msg
+checkHandleAvailability appContext h =
+    let
+        isAvailable res =
+            case res of
+                Err (Http.BadStatus 404) ->
+                    True
+
+                _ ->
+                    False
+    in
+    ShareApi.profile h
+        |> HttpApi.toRequest
+            (Decode.succeed False)
+            (isAvailable >> HandleAvailabilityCheckFinished h)
+        |> HttpApi.perform appContext.api
+
+
+
+-- VIEW
+
+
+handleToString : PotentialHandle -> String
+handleToString potentialHandle =
+    case potentialHandle of
+        Blank ->
+            ""
+
+        UserEntered raw ->
+            raw
+
+        CheckingAvailability handle ->
+            UserHandle.toUnprefixedString handle
+
+        NotAvailable handle ->
+            UserHandle.toUnprefixedString handle
+
+        Available handle ->
+            UserHandle.toUnprefixedString handle
+
+
+view : AppContext -> UserHandle -> Model -> AppDocument Msg
+view appContext conflictingHandle { potentialHandle } =
+    let
+        handleField =
+            TextField.fieldWithoutLabel UpdateHandle "Handle, e.g. @alice" (handleToString potentialHandle)
+                |> TextField.withHelpText "The unique identifier of your user used in URLs and project references like @unison/base."
+                |> TextField.withIcon Icon.at
+
+        disabledFinishButton =
+            Button.button
+                NoOp
+                "Finish Signup"
+                |> Button.positive
+                |> Button.disabled
+                |> Button.view
+
+        finishButton handle =
+            Button.button_
+                (Link.finishSignup appContext.api handle)
+                "Finish Signup"
+                |> Button.positive
+                |> Button.view
+
+        ( handleField_, finishButton_ ) =
+            case potentialHandle of
+                CheckingAvailability _ ->
+                    ( handleField
+                        |> TextField.withStatusIndicator StatusIndicator.working
+                    , disabledFinishButton
+                    )
+
+                Available handle ->
+                    ( handleField
+                        |> TextField.withStatusIndicator StatusIndicator.good
+                    , finishButton handle
+                    )
+
+                NotAvailable _ ->
+                    ( handleField
+                        |> TextField.withHelpText "This handle is currently taken by another user or organization."
+                        |> TextField.withStatusIndicator StatusIndicator.bad
+                        |> TextField.markAsInvalid
+                    , disabledFinishButton
+                    )
+
+                _ ->
+                    let
+                        h =
+                            handleToString potentialHandle
+                    in
+                    if UserHandle.isValidHandle h || String.length h <= 2 then
+                        ( handleField, disabledFinishButton )
+
+                    else
+                        ( handleField
+                            |> TextField.withHelpText
+                                "May only contain alphanumeric characters or hyphens. Can't have multiple consecutive hyphens. Can't begin or end with a hyphen. Max 39 characters."
+                            |> TextField.markAsInvalid
+                        , disabledFinishButton
+                        )
+
+        content =
+            [ Card.card
+                [ h1 [] [ text "Almost there..." ]
+                , p
+                    []
+                    [ text "Looks like the handle "
+                    , strong [] [ text (UserHandle.toString conflictingHandle) ]
+                    , text " is already taken."
+                    , br [] []
+                    , text "Pick another one to finish signing up to Unison Share."
+                    ]
+                , TextField.view handleField_
+                , footer [ class "actions" ] [ finishButton_ ]
+                ]
+                |> Card.withClassName "form"
+                |> Card.asContained
+                |> Card.view
+            ]
+
+        page =
+            PageLayout.centeredNarrowLayout
+                (PageContent.oneColumn content)
+                PageFooter.pageFooter
+                |> PageLayout.withSubduedBackground
+    in
+    { pageId = "finish-signup-page"
+    , title = "Finish Signup"
+    , appHeader = AppHeader.empty
+    , pageHeader = Nothing
+    , page = PageLayout.view page
+    , modal = Nothing
+    }

--- a/src/css/unison-share/page.css
+++ b/src/css/unison-share/page.css
@@ -1,6 +1,7 @@
 @import "./page/catalog-page.css";
 @import "./page/org-profile-page.css";
 @import "./page/org-people-page.css";
+@import "./page/finish-signup-page.css";
 @import "./page/user-profile-page.css";
 @import "./page/user-contributions-page.css";
 @import "./page/project-page.css";

--- a/src/css/unison-share/page/finish-signup-page.css
+++ b/src/css/unison-share/page/finish-signup-page.css
@@ -1,0 +1,23 @@
+.finish-signup-page {
+  & .form {
+    width: 35rem;
+    margin: 0 auto;
+
+    & .actions {
+      margin-top: 1.5rem;
+      display: flex;
+      flex-direction: row;
+      flex: 1;
+      width: 100%;
+      justify-content: flex-end;
+    }
+  }
+}
+
+@media only screen and (--u-viewport_max-md) {
+  .finish-signup-page {
+    & .form {
+      width: auto;
+    }
+  }
+}

--- a/tests/e2e/FinishSignupPage.spec.ts
+++ b/tests/e2e/FinishSignupPage.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect } from "@playwright/test";
+import * as API from "./TestHelpers/Api";
+import { userHandle } from "./TestHelpers/Data";
+
+test.beforeEach(async ({ page }) => {
+  await API.getWebsiteFeed(page);
+});
+
+test.describe("without being signed in", () => {
+  test.beforeEach(async ({ page }) => {
+    await API.getAccount(page, "NOT_SIGNED_IN");
+  });
+
+  test("can view the FinishSignupPage", async ({ page }) => {
+    const response = await page.goto(
+      `http://localhost:1234/finish-signup?conflictingHandle=${userHandle()}`,
+    );
+    expect(response?.status()).toBeLessThan(400);
+
+    await expect(page.getByText("Almost there...")).toBeVisible();
+  });
+});
+
+test.describe("when signed in", () => {
+  test.beforeEach(async ({ page }) => {
+    await API.getAccount(page, "@alice");
+  });
+
+  test("can *NOT* view the FinishSignupagePage", async ({ page }) => {
+    const response = await page.goto(
+      `http://localhost:1234/finish-signup?conflictingHandle=${userHandle()}`,
+    );
+    expect(response?.status()).toBeLessThan(400);
+
+    await expect(page.getByText("Almost there...")).not.toBeVisible();
+    await expect(page.getByText("Page not Found")).toBeVisible();
+  });
+});

--- a/tests/e2e/TestHelpers/Data.ts
+++ b/tests/e2e/TestHelpers/Data.ts
@@ -11,10 +11,14 @@ function account(handle: string) {
   };
 }
 
+function userHandle() {
+  return faker.lorem.slug(1);
+}
+
 function user(handle?: string) {
   const firstName = faker.person.firstName();
   const lastName = faker.person.lastName();
-  const handle_ = handle ? handle : faker.lorem.slug(1);
+  const handle_ = handle ? handle : userHandle();
 
   return {
     avatarUrl: faker.image.avatar(),
@@ -161,6 +165,7 @@ export {
   account,
   user,
   userDetails,
+  userHandle,
   org,
   contribution,
   contributionTimeline,


### PR DESCRIPTION
When the user signs up for the first time and if the handle is already taken, send them to this new /finish-signup page, allowing them to set another handle.

@ChrisPenner the url ended being: `/finish-signup?conflictingHandle=<SOME_UNPREFIXED_HANDLE>`