### PR TITLE
Add pagination support to Notifications

### DIFF
--- a/src/UnisonShare/Api.elm
+++ b/src/UnisonShare/Api.elm
@@ -27,6 +27,7 @@ import UnisonShare.DefinitionDiff as DefinitionDiff
 import UnisonShare.Notification as Notification exposing (NotificationStatus)
 import UnisonShare.OrgMember as OrgMember exposing (OrgMember)
 import UnisonShare.OrgRole as OrgRole
+import UnisonShare.Paginated as Paginated exposing (PageCursorParam(..))
 import UnisonShare.Project as Project exposing (ProjectVisibility)
 import UnisonShare.Project.ProjectRef as ProjectRef exposing (ProjectRef)
 import UnisonShare.ProjectCollaborator exposing (ProjectCollaborator)
@@ -189,15 +190,26 @@ session =
 -- NOTIFICATIONS
 
 
-notifications : Account a -> Maybe NotificationStatus -> Endpoint
-notifications account status =
+notifications : Account a -> Maybe NotificationStatus -> PageCursorParam -> Endpoint
+notifications account status paginationCursor =
     let
-        queryParams =
+        statusQueryParams =
             case status of
                 Just s ->
                     [ string "status" (Notification.statusToString s) ]
 
                 Nothing ->
+                    []
+
+        paginationQueryParams =
+            case paginationCursor of
+                PrevPage c ->
+                    [ string "prevCursor" (Paginated.cursorToString c) ]
+
+                NextPage c ->
+                    [ string "nextCursor" (Paginated.cursorToString c) ]
+
+                NoPageCursor ->
                     []
     in
     GET
@@ -207,7 +219,7 @@ notifications account status =
             , "notifications"
             , "hub"
             ]
-        , queryParams = queryParams
+        , queryParams = statusQueryParams ++ paginationQueryParams
         }
 
 

--- a/src/UnisonShare/Link.elm
+++ b/src/UnisonShare/Link.elm
@@ -11,6 +11,7 @@ import Lib.UserHandle as UserHandle exposing (UserHandle)
 import UI.Click as Click exposing (Click)
 import UnisonShare.BranchDiff.ChangeLineId exposing (ChangeLineId)
 import UnisonShare.Contribution.ContributionRef exposing (ContributionRef)
+import UnisonShare.Paginated exposing (PageCursorParam)
 import UnisonShare.Project.ProjectRef exposing (ProjectRef)
 import UnisonShare.Route as Route exposing (Route)
 import UnisonShare.Ticket.TicketRef exposing (TicketRef)
@@ -183,19 +184,19 @@ account =
     toClick Route.account
 
 
-notificationsAll : Click msg
-notificationsAll =
-    toClick Route.notificationsAll
+notificationsAll : PageCursorParam -> Click msg
+notificationsAll cursor =
+    toClick (Route.notificationsAll cursor)
 
 
-notificationsUnread : Click msg
-notificationsUnread =
-    toClick Route.notificationsUnread
+notificationsUnread : PageCursorParam -> Click msg
+notificationsUnread cursor =
+    toClick (Route.notificationsUnread cursor)
 
 
-notificationsArchive : Click msg
-notificationsArchive =
-    toClick Route.notificationsArchive
+notificationsArchive : PageCursorParam -> Click msg
+notificationsArchive cursor =
+    toClick (Route.notificationsArchive cursor)
 
 
 orgProfile : UserHandle -> Click msg

--- a/src/UnisonShare/Paginated.elm
+++ b/src/UnisonShare/Paginated.elm
@@ -1,0 +1,24 @@
+module UnisonShare.Paginated exposing (..)
+
+
+type PageCursorParam
+    = NoPageCursor
+    | PrevPage PageCursor
+    | NextPage PageCursor
+
+
+type PageCursor
+    = PageCursor String
+
+
+type Paginated a
+    = Paginated
+        { prev : Maybe PageCursor
+        , next : Maybe PageCursor
+        , items : List a
+        }
+
+
+cursorToString : PageCursor -> String
+cursorToString (PageCursor c) =
+    c

--- a/src/css/unison-share/page/notifications-page.css
+++ b/src/css/unison-share/page/notifications-page.css
@@ -13,6 +13,12 @@
     }
   }
 
+  & .notifications-page_content {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
   & .notifications {
     display: flex;
     flex-direction: column;
@@ -83,5 +89,13 @@
         color: var(--u-color_text_subdued);
       }
     }
+  }
+
+  & .pagination-controls {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+    justify-content: flex-end;
+    margin-top: 0.5rem;
   }
 }

--- a/tests/e2e/TestHelpers/Api.ts
+++ b/tests/e2e/TestHelpers/Api.ts
@@ -1,4 +1,5 @@
 // Backend API Stubs
+import { faker } from "@faker-js/faker";
 import { Page } from "@playwright/test";
 import {
   project,
@@ -303,7 +304,9 @@ async function getProjectContributionDiff(
 
 async function getNotificationsHub(page: Page, handle: string) {
   const data = {
-    notifications: [notification(), notification(), notification()],
+    prevCursor: null,
+    nextCursor: faker.lorem.slug(1),
+    items: [notification(), notification(), notification()],
   };
 
   return get(page, {


### PR DESCRIPTION
Add a new Paginated module with prev and next cursors for querying and tracking pagination in the URL all the way through to the API.

Hook up the NotificationsPage to used the new Paginated module.