### PR TITLE
Gate project visibility changes if public org

### DIFF
--- a/src/UnisonShare/Org.elm
+++ b/src/UnisonShare/Org.elm
@@ -26,11 +26,12 @@ import UnisonShare.OrgPermission as OrgPermission exposing (OrgPermission)
 import Url exposing (Url)
 
 
-type alias Org u =
-    { u
+type alias Org o =
+    { o
         | handle : UserHandle
         , name : Maybe String
         , avatarUrl : Maybe Url
+        , isCommercial : Bool
     }
 
 
@@ -107,11 +108,12 @@ canChangeOwner org =
 decodeDetails : Decode.Decoder OrgDetails
 decodeDetails =
     let
-        makeDetails handle name_ avatarUrl permissions =
+        makeDetails handle name_ avatarUrl permissions isCommercial =
             { handle = handle
             , name = name_
             , avatarUrl = avatarUrl
             , permissions = permissions
+            , isCommercial = isCommercial
             }
     in
     Decode.succeed makeDetails
@@ -119,18 +121,21 @@ decodeDetails =
         |> maybeAt [ "user", "name" ] string
         |> maybeAt [ "user", "avatarUrl" ] url
         |> required "permissions" OrgPermission.decodeList
+        |> required "isCommercial" Decode.bool
 
 
 decodeSummary : Decode.Decoder OrgSummary
 decodeSummary =
     let
-        makeSummary handle name_ avatarUrl =
+        makeSummary handle name_ avatarUrl isCommercial =
             { handle = handle
             , name = name_
             , avatarUrl = avatarUrl
+            , isCommercial = isCommercial
             }
     in
     Decode.succeed makeSummary
         |> requiredAt [ "user", "handle" ] UserHandle.decodeUnprefixed
         |> maybeAt [ "user", "name" ] string
         |> maybeAt [ "user", "avatarUrl" ] url
+        |> required "isCommercial" Decode.bool

--- a/src/UnisonShare/Page/ProjectPage.elm
+++ b/src/UnisonShare/Page/ProjectPage.elm
@@ -283,11 +283,17 @@ update appContext projectRef route msg model =
 
                 ( Settings settings, Success _ ) ->
                     let
-                        ( settings_, settingsCmd ) =
+                        ( fetchingCollabs, fetchingCollabsCmd ) =
                             ProjectSettingsPage.fetchProjectCollaborators appContext projectRef settings
+
+                        ( fetchingOwner, fetchingOwnerCmd ) =
+                            ProjectSettingsPage.fetchProjectOwner appContext projectRef fetchingCollabs
                     in
-                    ( { modelWithProject | subPage = Settings settings_ }
-                    , Cmd.map ProjectSettingsPageMsg settingsCmd
+                    ( { modelWithProject | subPage = Settings fetchingOwner }
+                    , Cmd.batch
+                        [ Cmd.map ProjectSettingsPageMsg fetchingCollabsCmd
+                        , Cmd.map ProjectSettingsPageMsg fetchingOwnerCmd
+                        ]
                     )
 
                 _ ->

--- a/src/css/unison-share/page/project-settings-page.css
+++ b/src/css/unison-share/page/project-settings-page.css
@@ -1,11 +1,23 @@
 .project-settings-page .settings-content {
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: 1rem;
 }
 
-.project-settings-page .settings-content .card {
+.project-settings-page .settings-content .card,
+.project-settings-page .settings-content .card .form {
   position: relative;
+}
+
+.project-settings-page .settings-content .disabled-overlay {
+  background: var(--u-color_container);
+  border-radius: var(--border-radius-base);
+  opacity: 0.75;
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
 }
 
 .project-settings-page .settings-content h2 {

--- a/tests/e2e/TestHelpers/Data.ts
+++ b/tests/e2e/TestHelpers/Data.ts
@@ -60,6 +60,7 @@ function org(handle?: string) {
     orgId: faker.string.uuid(),
     kind: "org",
     permissions: [],
+    isCommercial: false,
   };
 }
 


### PR DESCRIPTION
If a project is owned by a public org, don't show the form to change the project visibility to private. Instead show a short explanation.