### PR TITLE
Add project subscribe button

### DIFF
--- a/src/UnisonShare/Api.elm
+++ b/src/UnisonShare/Api.elm
@@ -1168,6 +1168,23 @@ updateProjectFav projectRef isFaved =
         }
 
 
+updateProjectSubscription : ProjectRef -> Bool -> Endpoint
+updateProjectSubscription projectRef isSubscribed =
+    let
+        ( handle, slug ) =
+            ProjectRef.toApiStringParts projectRef
+
+        body =
+            Encode.object [ ( "isSubscribed", Encode.bool isSubscribed ) ]
+                |> Http.jsonBody
+    in
+    PUT
+        { path = [ "users", handle, "projects", slug, "subscription" ]
+        , queryParams = []
+        , body = body
+        }
+
+
 type ProjectUpdate
     = ProjectDescriptionUpdate { summary : Maybe String, tags : Set String }
     | ProjectSettingsUpdate { visibility : ProjectVisibility }

--- a/src/UnisonShare/Page/ProjectOverviewPage.elm
+++ b/src/UnisonShare/Page/ProjectOverviewPage.elm
@@ -701,21 +701,33 @@ view_ session project model =
         subButton icon label =
             Button.iconThenLabel ToggleProjectSubscription icon label
                 |> Button.outlined
+                |> Button.view
 
         subscription =
             case ( session, project.isSubscribed ) of
-                ( Session.SignedIn _, Project.NotSubscribed ) ->
-                    subButton Icon.bellSlash "Subscribe"
+                ( Session.SignedIn account, Project.NotSubscribed ) ->
+                    if account.isSuperAdmin then
+                        subButton Icon.bellSlash "Subscribe"
 
-                ( Session.SignedIn _, Project.Subscribed ) ->
-                    subButton Icon.bell "Subscribed"
+                    else
+                        UI.nothing
 
-                ( Session.SignedIn _, Project.JustSubscribed ) ->
-                    subButton Icon.bell "Subscribed"
+                ( Session.SignedIn account, Project.Subscribed ) ->
+                    if account.isSuperAdmin then
+                        subButton Icon.bell "Subscribed"
+
+                    else
+                        UI.nothing
+
+                ( Session.SignedIn account, Project.JustSubscribed ) ->
+                    if account.isSuperAdmin then
+                        subButton Icon.bell "Subscribed"
+
+                    else
+                        UI.nothing
 
                 _ ->
-                    subButton Icon.bellSlash "Subscribe"
-                        |> Button.disabled
+                    UI.nothing
 
         favKpi icon =
             viewKpi
@@ -758,7 +770,7 @@ view_ session project model =
                    "Total downloads for the last 4 weeks"
                ]
             -}
-            , subscription |> Button.view
+            , subscription
             , Button.iconThenLabel ShowUseProjectModal Icon.download "Use Project"
                 |> Button.medium
                 |> Button.positive

--- a/src/UnisonShare/Page/ProjectOverviewPage.elm
+++ b/src/UnisonShare/Page/ProjectOverviewPage.elm
@@ -120,6 +120,7 @@ type Msg
     | SaveDescriptionFinished (HttpResult ())
     | CloseModal
     | ToggleProjectFav
+    | ToggleProjectSubscription
     | ShowUseProjectModal
     | Keydown KeyboardEvent
     | KeyboardShortcutMsg KeyboardShortcut.Msg
@@ -133,6 +134,7 @@ type OutMsg
       -- opened from multiple places)
     | RequestToShowUseProjectModal
     | RequestToToggleProjectFav
+    | RequestToToggleProjectSubscription
     | ProjectDescriptionUpdated { summary : Maybe String, tags : Set String }
 
 
@@ -260,6 +262,9 @@ update appContext projectRef project msg model =
 
         ToggleProjectFav ->
             ( model, Cmd.none, RequestToToggleProjectFav )
+
+        ToggleProjectSubscription ->
+            ( model, Cmd.none, RequestToToggleProjectSubscription )
 
         ShowUseProjectModal ->
             ( model, Cmd.none, RequestToShowUseProjectModal )
@@ -693,6 +698,25 @@ view_ session project model =
                     )
                 |> KpiTag.view
 
+        subButton icon label =
+            Button.iconThenLabel ToggleProjectSubscription icon label
+                |> Button.outlined
+
+        subscription =
+            case ( session, project.isSubscribed ) of
+                ( Session.SignedIn _, Project.NotSubscribed ) ->
+                    subButton Icon.bellSlash "Subscribe"
+
+                ( Session.SignedIn _, Project.Subscribed ) ->
+                    subButton Icon.bell "Subscribed"
+
+                ( Session.SignedIn _, Project.JustSubscribed ) ->
+                    subButton Icon.bell "Subscribed"
+
+                _ ->
+                    subButton Icon.bellSlash "Subscribe"
+                        |> Button.disabled
+
         favKpi icon =
             viewKpi
                 icon
@@ -734,6 +758,7 @@ view_ session project model =
                    "Total downloads for the last 4 weeks"
                ]
             -}
+            , subscription |> Button.view
             , Button.iconThenLabel ShowUseProjectModal Icon.download "Use Project"
                 |> Button.medium
                 |> Button.positive

--- a/src/UnisonShare/Page/ProjectPage.elm
+++ b/src/UnisonShare/Page/ProjectPage.elm
@@ -420,6 +420,13 @@ update appContext projectRef route msg model =
                                     in
                                     ( { model | modal = NoModal, project = Success project_ }, setProjectFav appContext project_ )
 
+                                ( Success project, ProjectOverviewPage.RequestToToggleProjectSubscription ) ->
+                                    let
+                                        project_ =
+                                            Project.toggleSubscription project
+                                    in
+                                    ( { model | modal = NoModal, project = Success project_ }, setProjectSubscription appContext project_ )
+
                                 ( Success project, ProjectOverviewPage.ProjectDescriptionUpdated description ) ->
                                     let
                                         updatedProject =

--- a/src/UnisonShare/Page/ProjectPage.elm
+++ b/src/UnisonShare/Page/ProjectPage.elm
@@ -205,6 +205,8 @@ type Msg
     | FetchProjectFinished (WebData ProjectDetails)
     | ToggleProjectFav
     | SetProjectFavFinished Bool (HttpResult ())
+    | ToggleProjectSubscription
+    | SetProjectSubscriptionFinished Bool (HttpResult ())
     | ShowUseProjectModal
     | ShowDeleteProjectModal
     | YesDeleteProject
@@ -317,6 +319,28 @@ update appContext projectRef route msg model =
                 ( Success project, Err _ ) ->
                     -- Reverting the fav change by re-toggling Project.isFaved.
                     ( { model | modal = NoModal, project = Success (Project.toggleFav project) }, Cmd.none )
+
+                _ ->
+                    ( model, Cmd.none )
+
+        ( _, ToggleProjectSubscription ) ->
+            case model.project of
+                Success project ->
+                    let
+                        project_ =
+                            Project.toggleSubscription project
+                    in
+                    ( { model | project = Success project_ }, setProjectSubscription appContext project_ )
+
+                _ ->
+                    ( model, Cmd.none )
+
+        ( _, SetProjectSubscriptionFinished _ isSubscribedResult ) ->
+            case ( model.project, isSubscribedResult ) of
+                -- We have a project, but the API request to subscribing failed
+                ( Success project, Err _ ) ->
+                    -- Reverting the subscription change by re-toggling Project.isSubscribed.
+                    ( { model | modal = NoModal, project = Success (Project.toggleSubscription project) }, Cmd.none )
 
                 _ ->
                     ( model, Cmd.none )
@@ -825,6 +849,17 @@ setProjectFav appContext project =
     in
     ShareApi.updateProjectFav project.ref isFaved
         |> HttpApi.toRequestWithEmptyResponse (SetProjectFavFinished isFaved)
+        |> HttpApi.perform appContext.api
+
+
+setProjectSubscription : AppContext -> ProjectDetails -> Cmd Msg
+setProjectSubscription appContext project =
+    let
+        isSubscribed =
+            Project.isSubscribedToBool project.isSubscribed
+    in
+    ShareApi.updateProjectSubscription project.ref isSubscribed
+        |> HttpApi.toRequestWithEmptyResponse (SetProjectSubscriptionFinished isSubscribed)
         |> HttpApi.perform appContext.api
 
 
@@ -1341,6 +1376,7 @@ view appContext projectRef model =
             ProjectPageHeader.projectPageHeader
                 appContext.session
                 { toggleFavMsg = ToggleProjectFav
+                , toggleSubscriptionMsg = ToggleProjectSubscription
                 , useProjectButtonClickMsg = ShowUseProjectModal
                 , mobileNavToggleMsg = ToggleMobileNav
                 , mobileNavIsOpen = model.mobileNavIsOpen

--- a/src/UnisonShare/Page/ProjectPageHeader.elm
+++ b/src/UnisonShare/Page/ProjectPageHeader.elm
@@ -148,20 +148,32 @@ viewRightSide session toggleFavMsg toggleSubscriptionMsg useProjectButtonClickMs
 
         subscribeButton iconOnly p =
             case ( session, p.isSubscribed ) of
-                ( Session.SignedIn _, Project.NotSubscribed ) ->
-                    subscribeButton_ iconOnly Icon.bellSlash "Subscribe"
-                        |> Button.outlined
-                        |> Button.view
+                ( Session.SignedIn account, Project.NotSubscribed ) ->
+                    if account.isSuperAdmin then
+                        subscribeButton_ iconOnly Icon.bellSlash "Subscribe"
+                            |> Button.outlined
+                            |> Button.view
 
-                ( Session.SignedIn _, Project.Subscribed ) ->
-                    subscribeButton_ iconOnly Icon.bell "Unsubscribe"
-                        |> Button.outlined
-                        |> Button.view
+                    else
+                        UI.nothing
 
-                ( Session.SignedIn _, Project.JustSubscribed ) ->
-                    subscribeButton_ iconOnly Icon.bell "Unsubscribe"
-                        |> Button.outlined
-                        |> Button.view
+                ( Session.SignedIn account, Project.Subscribed ) ->
+                    if account.isSuperAdmin then
+                        subscribeButton_ iconOnly Icon.bell "Unsubscribe"
+                            |> Button.outlined
+                            |> Button.view
+
+                    else
+                        UI.nothing
+
+                ( Session.SignedIn account, Project.JustSubscribed ) ->
+                    if account.isSuperAdmin then
+                        subscribeButton_ iconOnly Icon.bell "Unsubscribe"
+                            |> Button.outlined
+                            |> Button.view
+
+                    else
+                        UI.nothing
 
                 _ ->
                     UI.nothing

--- a/src/css/unison-share/page/project-page.css
+++ b/src/css/unison-share/page/project-page.css
@@ -1,3 +1,21 @@
+.project-page .page-header .button {
+  --u-color_text-on-action-outlined: var(--color-gray-lighten-50);
+  --u-color_icon-on-action-outlined: var(--color-gray-lighten-20);
+  --u-color_border-on-action-outlined: var(--color-gray-base);
+  --u-color_action_outlined: var(--color-gray-darken-20);
+  --u-color_text-on-action-outlined_hovered: var(--color-gray-lighten-100);
+  --u-color_icon-on-action-outlined_hovered: var(--color-gray-lighten-30);
+  --u-color_text-on-action-outlined_hovered: var(--color-gray-lighten-100);
+  --u-color_action_outlined_hovered: var(--color-gray-darken-10);
+  --u-color_border-on-action-outlined_hovered: var(--color-gray-lighten-20);
+}
+
+.project-page .page-header .actions {
+  display: flex;
+  flex-direction: row;
+  gap: 0.5rem;
+}
+
 .project-page .page-header .page-header_right-side .kpis {
   display: flex;
   flex-direction: row;
@@ -12,7 +30,7 @@
 }
 
 .project-page .page-header .page-header_right-side .kpi .tooltip {
-  margin-top: 2px;
+  margin-top: 0.375rem;
   left: -0.5rem;
   pointer-events: none;
 }

--- a/tests/UnisonShare/ProjectTests.elm
+++ b/tests/UnisonShare/ProjectTests.elm
@@ -153,6 +153,7 @@ projectDetailsForSub isSubscribed =
     , latestVersion = Nothing
     , defaultBranch = Nothing
     , permissions = []
+    , isPremiumProject = True
     , createdAt = DateTime.fromPosix (Time.millisToPosix 1)
     , updatedAt = DateTime.fromPosix (Time.millisToPosix 1)
     }

--- a/tests/UnisonShare/ProjectTests.elm
+++ b/tests/UnisonShare/ProjectTests.elm
@@ -51,14 +51,14 @@ toggleFav =
         resultFor isFaved =
             let
                 p =
-                    Project.toggleFav (projectDetails isFaved 3)
+                    Project.toggleFav (projectDetailsForFav isFaved 3)
             in
             ( p.isFaved, p.numFavs )
     in
     describe "Project.toggleFav"
-        [ test "toggles Unknown to Unknown" <|
+        [ test "toggles FavUnknown to FavUnknown" <|
             \_ ->
-                Expect.equal (resultFor Project.Unknown) ( Project.Unknown, 3 )
+                Expect.equal (resultFor Project.FavUnknown) ( Project.FavUnknown, 3 )
         , test "toggles Faved to NotFaved" <|
             \_ ->
                 Expect.equal (resultFor Project.Faved) ( Project.NotFaved, 2 )
@@ -68,6 +68,32 @@ toggleFav =
         , test "toggles NotFaved to JustFaved" <|
             \_ ->
                 Expect.equal (resultFor Project.NotFaved) ( Project.JustFaved, 4 )
+        ]
+
+
+toggleSubscription : Test
+toggleSubscription =
+    let
+        resultFor isSubscribed =
+            let
+                p =
+                    Project.toggleSubscription (projectDetailsForSub isSubscribed)
+            in
+            p.isSubscribed
+    in
+    describe "Project.toggleSubscription"
+        [ test "toggles SubUnknown to SubUnknown" <|
+            \_ ->
+                Expect.equal (resultFor Project.SubUnknown) Project.SubUnknown
+        , test "toggles Subscribed to NotSubscribed" <|
+            \_ ->
+                Expect.equal (resultFor Project.Subscribed) Project.NotSubscribed
+        , test "toggles JustSubscribed to NotSubscribed" <|
+            \_ ->
+                Expect.equal (resultFor Project.JustSubscribed) Project.NotSubscribed
+        , test "toggles NotSubscribed to JustSubscribed" <|
+            \_ ->
+                Expect.equal (resultFor Project.NotSubscribed) Project.JustSubscribed
         ]
 
 
@@ -85,13 +111,14 @@ project =
     }
 
 
-projectDetails : Project.IsFaved -> Int -> Project.ProjectDetails
-projectDetails isFaved numFavs =
+projectDetailsForFav : Project.IsFaved -> Int -> Project.ProjectDetails
+projectDetailsForFav isFaved numFavs =
     { ref =
         ProjectRef.projectRef
             (UserHandle.unsafeFromString "unison")
             (ProjectSlug.unsafeFromString "http")
     , isFaved = isFaved
+    , isSubscribed = Project.NotSubscribed
     , numFavs = numFavs
     , numActiveContributions = 0
     , numOpenTickets = 0
@@ -105,4 +132,27 @@ projectDetails isFaved numFavs =
     , createdAt = DateTime.fromPosix (Time.millisToPosix 1)
     , updatedAt = DateTime.fromPosix (Time.millisToPosix 1)
     , isPremiumProject = False
+    }
+
+
+projectDetailsForSub : Project.IsSubscribed -> Project.ProjectDetails
+projectDetailsForSub isSubscribed =
+    { ref =
+        ProjectRef.projectRef
+            (UserHandle.unsafeFromString "unison")
+            (ProjectSlug.unsafeFromString "http")
+    , isFaved = Project.NotFaved
+    , isSubscribed = isSubscribed
+    , numFavs = 42
+    , numActiveContributions = 0
+    , numOpenTickets = 0
+    , releaseDownloads = ReleaseDownloads []
+    , summary = Just "hi i'm a summary"
+    , tags = Set.empty
+    , visibility = Project.Public
+    , latestVersion = Nothing
+    , defaultBranch = Nothing
+    , permissions = []
+    , createdAt = DateTime.fromPosix (Time.millisToPosix 1)
+    , updatedAt = DateTime.fromPosix (Time.millisToPosix 1)
     }


### PR DESCRIPTION
Add a new button to the project screens, allowing users to subscribe to notifications for that project.

Currently this uses an imagined API similar to that of fav'ing a project.