### PR TITLE
Migrate to using prev and next cursor explicitly

### DIFF
--- a/src/UnisonShare/Api.elm
+++ b/src/UnisonShare/Api.elm
@@ -27,7 +27,7 @@ import UnisonShare.DefinitionDiff as DefinitionDiff
 import UnisonShare.Notification as Notification exposing (NotificationStatus)
 import UnisonShare.OrgMember as OrgMember exposing (OrgMember)
 import UnisonShare.OrgRole as OrgRole
-import UnisonShare.Paginated as Paginated exposing (PageCursorParam(..))
+import UnisonShare.Paginated as Paginated exposing (PageCursorParam)
 import UnisonShare.Project as Project exposing (ProjectVisibility)
 import UnisonShare.Project.ProjectRef as ProjectRef exposing (ProjectRef)
 import UnisonShare.ProjectCollaborator exposing (ProjectCollaborator)
@@ -77,7 +77,7 @@ type alias UserBranchesParams =
     { searchQuery : Maybe String
     , projectRef : Maybe ProjectRef
     , limit : Int
-    , cursor : Maybe String
+    , cursor : PageCursorParam
     }
 
 
@@ -86,10 +86,7 @@ userBranches handle params =
     let
         queryParams =
             int "limit" params.limit
-                :: (params.cursor
-                        |> Maybe.map (string "cursor")
-                        |> MaybeE.toList
-                   )
+                :: Paginated.toQueryParams params.cursor
                 ++ (params.searchQuery
                         |> Maybe.map (string "name-prefix")
                         |> MaybeE.toList
@@ -202,15 +199,7 @@ notifications account status paginationCursor =
                     []
 
         paginationQueryParams =
-            case paginationCursor of
-                PrevPage c ->
-                    [ string "prevCursor" (Paginated.cursorToString c) ]
-
-                NextPage c ->
-                    [ string "nextCursor" (Paginated.cursorToString c) ]
-
-                NoPageCursor ->
-                    []
+            Paginated.toQueryParams paginationCursor
     in
     GET
         { path =
@@ -363,7 +352,7 @@ type alias ProjectBranchesParams =
     { kind : ProjectBranchesKindFilter
     , searchQuery : Maybe String
     , limit : Int
-    , cursor : Maybe String
+    , cursor : PageCursorParam
     }
 
 
@@ -389,10 +378,7 @@ projectBranches projectRef params =
 
         queryParams =
             [ kind, int "limit" params.limit ]
-                ++ (params.cursor
-                        |> Maybe.map (string "cursor")
-                        |> MaybeE.toList
-                   )
+                ++ Paginated.toQueryParams params.cursor
                 ++ (params.searchQuery
                         |> Maybe.map (string "name-prefix")
                         |> MaybeE.toList

--- a/src/UnisonShare/Page/ProjectBranchesPage.elm
+++ b/src/UnisonShare/Page/ProjectBranchesPage.elm
@@ -28,6 +28,7 @@ import UnisonShare.AppContext exposing (AppContext)
 import UnisonShare.BranchSummary exposing (BranchSummary)
 import UnisonShare.Link as Link
 import UnisonShare.PageFooter as PageFooter
+import UnisonShare.Paginated as Paginated
 import UnisonShare.Project as Project exposing (ProjectDetails)
 import UnisonShare.Project.ProjectRef as ProjectRef exposing (ProjectRef)
 import UnisonShare.Session as Session exposing (Session)
@@ -123,7 +124,7 @@ fetchBranches appContext projectRef =
             { kind = ShareApi.AllBranches Nothing
             , searchQuery = Nothing
             , limit = 100
-            , cursor = Nothing
+            , cursor = Paginated.NoPageCursor
             }
     in
     ShareApi.projectBranches projectRef params

--- a/src/UnisonShare/Page/ProjectContributionsPage.elm
+++ b/src/UnisonShare/Page/ProjectContributionsPage.elm
@@ -31,6 +31,7 @@ import UnisonShare.Contribution.ContributionRef as ContributionRef
 import UnisonShare.Contribution.ContributionStatus as ContributionStatus
 import UnisonShare.Link as Link
 import UnisonShare.PageFooter as PageFooter
+import UnisonShare.Paginated as Paginated
 import UnisonShare.Project as Project exposing (ProjectDetails)
 import UnisonShare.Project.ProjectRef exposing (ProjectRef)
 import UnisonShare.ProjectContributionFormModal as ProjectContributionFormModal
@@ -82,7 +83,7 @@ init appContext projectRef =
                             { kind = ShareApi.ContributorBranches (Just a.handle)
                             , searchQuery = Nothing
                             , limit = 3
-                            , cursor = Nothing
+                            , cursor = Paginated.NoPageCursor
                             }
                       , fetchBranches FetchProjectBranchesFinished
                             appContext
@@ -90,7 +91,7 @@ init appContext projectRef =
                             { kind = ShareApi.ProjectBranches
                             , searchQuery = Nothing
                             , limit = 3
-                            , cursor = Nothing
+                            , cursor = Paginated.NoPageCursor
                             }
                       ]
                     )

--- a/src/UnisonShare/Page/ProjectReleasesPage.elm
+++ b/src/UnisonShare/Page/ProjectReleasesPage.elm
@@ -42,6 +42,7 @@ import UnisonShare.CodeBrowsingContext as CodeBrowsingContext
 import UnisonShare.InteractiveDoc as InteractiveDoc
 import UnisonShare.Link as Link
 import UnisonShare.PageFooter as PageFooter
+import UnisonShare.Paginated as Paginated
 import UnisonShare.Project as Project exposing (ProjectDetails)
 import UnisonShare.Project.ProjectRef as ProjectRef exposing (ProjectRef)
 import UnisonShare.Project.Release as Release exposing (Release)
@@ -423,7 +424,7 @@ fetchReleaseDrafts appContext projectRef =
             { kind = ShareApi.ProjectBranches
             , searchQuery = Just "releases/drafts/"
             , limit = 10
-            , cursor = Nothing
+            , cursor = Paginated.NoPageCursor
             }
     in
     ShareApi.projectBranches projectRef params

--- a/src/UnisonShare/Page/UserContributionsPage.elm
+++ b/src/UnisonShare/Page/UserContributionsPage.elm
@@ -31,6 +31,7 @@ import UnisonShare.Api as ShareApi
 import UnisonShare.AppContext exposing (AppContext)
 import UnisonShare.Link as Link
 import UnisonShare.PageFooter as PageFooter
+import UnisonShare.Paginated as Paginated
 import UnisonShare.Project as Project exposing (Project)
 import UnisonShare.Project.ProjectListing as ProjectListing
 import UnisonShare.Project.ProjectRef as ProjectRef
@@ -79,7 +80,7 @@ init appContext handle =
             { searchQuery = Nothing
             , projectRef = Nothing
             , limit = 100
-            , cursor = Nothing
+            , cursor = Paginated.NoPageCursor
             }
 
         model =
@@ -137,7 +138,7 @@ update appContext handle msg model =
                                 { searchQuery = Just query
                                 , projectRef = Nothing
                                 , limit = 100
-                                , cursor = Nothing
+                                , cursor = Paginated.NoPageCursor
                                 }
                         in
                         fetchContributions (FetchSearchResultsFinished query) appContext handle params

--- a/src/UnisonShare/Paginated.elm
+++ b/src/UnisonShare/Paginated.elm
@@ -1,5 +1,7 @@
 module UnisonShare.Paginated exposing (..)
 
+import Url.Builder exposing (QueryParameter, string)
+
 
 type PageCursorParam
     = NoPageCursor
@@ -22,3 +24,24 @@ type Paginated a
 cursorToString : PageCursor -> String
 cursorToString (PageCursor c) =
     c
+
+
+toQueryParam : PageCursorParam -> Maybe QueryParameter
+toQueryParam param =
+    case param of
+        NoPageCursor ->
+            Nothing
+
+        PrevPage c ->
+            Just (string "cursor" (cursorToString c))
+
+        NextPage c ->
+            Just (string "cursor" (cursorToString c))
+
+
+toQueryParams : PageCursorParam -> List QueryParameter
+toQueryParams param =
+    param
+        |> toQueryParam
+        |> Maybe.map List.singleton
+        |> Maybe.withDefault []

--- a/src/UnisonShare/ProjectContributionFormModal.elm
+++ b/src/UnisonShare/ProjectContributionFormModal.elm
@@ -35,6 +35,7 @@ import UnisonShare.Contribution as Contribution exposing (ContributionSummary)
 import UnisonShare.Contribution.ContributionRef as ContributionRef exposing (ContributionRef)
 import UnisonShare.Contribution.ContributionStatus as ContributionStatus exposing (ContributionStatus)
 import UnisonShare.Link as Link
+import UnisonShare.Paginated as Paginated
 import UnisonShare.Project as Project exposing (ProjectDetails)
 import UnisonShare.Project.ProjectRef as ProjectRef exposing (ProjectRef)
 import UnisonShare.SearchBranchSheet as SearchBranchSheet
@@ -389,14 +390,14 @@ fetchRecentBranches appContext currentUser projectRef =
             { kind = ShareApi.ContributorBranches (Just currentUser.handle)
             , searchQuery = Nothing
             , limit = 3
-            , cursor = Nothing
+            , cursor = Paginated.NoPageCursor
             }
 
         projectBranchesParams =
             { kind = ShareApi.ProjectBranches
             , searchQuery = Nothing
             , limit = 3
-            , cursor = Nothing
+            , cursor = Paginated.NoPageCursor
             }
     in
     Task.map2

--- a/src/UnisonShare/PublishProjectReleaseModal.elm
+++ b/src/UnisonShare/PublishProjectReleaseModal.elm
@@ -25,6 +25,7 @@ import UnisonShare.AppContext as AppContext exposing (AppContext)
 import UnisonShare.BranchSummary as BranchSummary exposing (BranchSummary)
 import UnisonShare.CodeBrowsingContext as CodeBrowsingContext
 import UnisonShare.InteractiveDoc as InteractiveDoc
+import UnisonShare.Paginated as Paginated
 import UnisonShare.Project.ProjectRef exposing (ProjectRef)
 import UnisonShare.Project.Release as Release exposing (Release)
 import UnisonShare.SearchBranchSheet as SearchBranchSheet
@@ -309,7 +310,7 @@ fetchLatestBranches appContext projectRef =
         { kind = ShareApi.ProjectBranches
         , searchQuery = Nothing
         , limit = 3
-        , cursor = Nothing
+        , cursor = Paginated.NoPageCursor
         }
         |> HttpApi.toRequest (Decode.field "items" (Decode.list BranchSummary.decode))
             (RemoteData.fromResult >> FetchLatestBranchesFinished)

--- a/src/UnisonShare/SearchBranchSheet.elm
+++ b/src/UnisonShare/SearchBranchSheet.elm
@@ -21,6 +21,7 @@ import UI.Tag as Tag
 import UnisonShare.Api as ShareApi exposing (ProjectBranchesKindFilter)
 import UnisonShare.AppContext exposing (AppContext)
 import UnisonShare.BranchSummary as BranchSummary exposing (BranchSummary)
+import UnisonShare.Paginated as Paginated
 import UnisonShare.Project.ProjectRef exposing (ProjectRef)
 
 
@@ -85,7 +86,7 @@ update appContext projectRef msg model =
                     { kind = model.branchKindFilter
                     , searchQuery = Just query
                     , limit = 10
-                    , cursor = Nothing
+                    , cursor = Paginated.NoPageCursor
                     }
                 , NoOutMsg
                 )

--- a/src/UnisonShare/SwitchBranch.elm
+++ b/src/UnisonShare/SwitchBranch.elm
@@ -13,6 +13,7 @@ import UnisonShare.Api as ShareApi
 import UnisonShare.AppContext exposing (AppContext)
 import UnisonShare.BranchSummary as BranchSummary exposing (BranchSummary)
 import UnisonShare.Link as Link
+import UnisonShare.Paginated as Paginated
 import UnisonShare.Project.ProjectRef exposing (ProjectRef)
 import UnisonShare.SearchBranchSheet as SearchBranchSheet
 import UnisonShare.Session as Session
@@ -79,7 +80,7 @@ update appContext projectRef msg model =
                                 { kind = ShareApi.ContributorBranches (Just handle)
                                 , searchQuery = Nothing
                                 , limit = 3
-                                , cursor = Nothing
+                                , cursor = Paginated.NoPageCursor
                                 }
                             , Just RemoteData.Loading
                             )
@@ -96,7 +97,7 @@ update appContext projectRef msg model =
                     { kind = ShareApi.ProjectBranches
                     , searchQuery = Nothing
                     , limit = 3
-                    , cursor = Nothing
+                    , cursor = Paginated.NoPageCursor
                     }
             in
             ( Open sheet

--- a/tests/e2e/TestHelpers/Data.ts
+++ b/tests/e2e/TestHelpers/Data.ts
@@ -179,7 +179,8 @@ function timelineCommentEvent() {
 
 function contributionTimeline(events?: unknown[]) {
   return {
-    cursor: faker.string.uuid(),
+    prevCursor: faker.string.uuid(),
+    nextCursor: faker.string.uuid(),
     items: events || [
       contributionStatusChangeEvent(),
       timelineCommentEvent(),


### PR DESCRIPTION
The API (with https://github.com/unisoncomputing/share-api/pull/79) now supports a previous and a next cursor. Update the API integration to match.