### PR TITLE
Project: Don't show the Finder with an open modal

### DIFF
--- a/src/UnisonShare/Page/ProjectOverviewPage.elm
+++ b/src/UnisonShare/Page/ProjectOverviewPage.elm
@@ -360,7 +360,7 @@ keydown appContext model config keyboardEvent =
         noOp =
             ( model, Cmd.none, None )
     in
-    if Finder.isShowFinderKeyboardShortcut appContext.operatingSystem shortcut then
+    if Finder.isShowFinderKeyboardShortcut appContext.operatingSystem shortcut && model.modal == NoModal then
         let
             ( finder, cmd ) =
                 Finder.init config


### PR DESCRIPTION
## Problem
On the project overview page, while having a modal open--say the edit summary modal--hitting the keyboard shortcut (/) to open the Finder (for searching definitions) would dismiss the active modal and cause the user to loose their current work and flow.

## Solution
Disable this behavior by simply checking if a modal is open or not.

Fixes https://github.com/unisonweb/website/issues/88