### PR TITLE
Improve loading state of OmniSearch

### DIFF
--- a/elm-git.json
+++ b/elm-git.json
@@ -1,7 +1,7 @@
 {
     "git-dependencies": {
         "direct": {
-            "https://github.com/unisonweb/ui-core": "f23522628f97e15669d5d8323d6479cc97530951"
+            "https://github.com/unisonweb/ui-core": "d4f539c5aa0ffa73ce3c7ef42f7d78850afbf8df"
         },
         "indirect": {}
     }


### PR DESCRIPTION
Instead of showing an empty state when there's still 1 of the 2 OmniSearch searches going, wait till both are finished by using the new Lib.MultiSearch datastructure.
