### PR TITLE
Use UCM Desktop Workspace with dependents support

### DIFF
--- a/elm-git.json
+++ b/elm-git.json
@@ -1,7 +1,7 @@
 {
     "git-dependencies": {
         "direct": {
-            "https://github.com/unisonweb/ui-core": "0e0ba00113beb947a101e8109ad72bc49327dd21"
+            "https://github.com/unisonweb/ui-core": "9e3cc7adc6243d831d8c21b560a53b7d427e44d8"
         },
         "indirect": {}
     }

--- a/review/suppressed/NoUnused.Modules.json
+++ b/review/suppressed/NoUnused.Modules.json
@@ -5,16 +5,16 @@
   "suppressions": [
     { "count": 1, "filePath": "elm-stuff/gitdeps/github.com/unisonweb/ui-core/src/Code/Browser.elm" },
     { "count": 1, "filePath": "elm-stuff/gitdeps/github.com/unisonweb/ui-core/src/Code/DefinitionDetailTooltip.elm" },
+    { "count": 1, "filePath": "elm-stuff/gitdeps/github.com/unisonweb/ui-core/src/Code/Workspace.elm" },
     { "count": 1, "filePath": "elm-stuff/gitdeps/github.com/unisonweb/ui-core/src/Lib/Paginated.elm" },
     { "count": 1, "filePath": "elm-stuff/gitdeps/github.com/unisonweb/ui-core/src/Lib/ProdDebug.elm" },
     { "count": 1, "filePath": "elm-stuff/gitdeps/github.com/unisonweb/ui-core/src/Lib/ScrollEvent.elm" },
-    { "count": 1, "filePath": "elm-stuff/gitdeps/github.com/unisonweb/ui-core/src/SplitPane/SplitPane.elm" },
     { "count": 1, "filePath": "elm-stuff/gitdeps/github.com/unisonweb/ui-core/src/UI/AppDocument.elm" },
     { "count": 1, "filePath": "elm-stuff/gitdeps/github.com/unisonweb/ui-core/src/UI/AvatarStack.elm" },
     { "count": 1, "filePath": "elm-stuff/gitdeps/github.com/unisonweb/ui-core/src/UI/Banner.elm" },
-    { "count": 1, "filePath": "elm-stuff/gitdeps/github.com/unisonweb/ui-core/src/UI/ContextualTag.elm" },
     { "count": 1, "filePath": "elm-stuff/gitdeps/github.com/unisonweb/ui-core/src/UI/ExternalLinkIcon.elm" },
     { "count": 1, "filePath": "elm-stuff/gitdeps/github.com/unisonweb/ui-core/src/UI/Toolbar.elm" },
+    { "count": 1, "filePath": "src/Code2/Workspace/WorkspaceContext.elm" },
     { "count": 1, "filePath": "src/UnisonShare/RichComment.elm" },
     { "count": 1, "filePath": "src/UnisonShare/Util.elm" }
   ]

--- a/src/Code2/Workspace/DefinitionItem.elm
+++ b/src/Code2/Workspace/DefinitionItem.elm
@@ -1,0 +1,303 @@
+module Code2.Workspace.DefinitionItem exposing (..)
+
+import Code.Definition.AbilityConstructor as AbilityConstructor exposing (AbilityConstructor(..), AbilityConstructorDetail)
+import Code.Definition.DataConstructor as DataConstructor exposing (DataConstructor(..), DataConstructorDetail)
+import Code.Definition.Doc as Doc exposing (Doc)
+import Code.Definition.Info as Info
+import Code.Definition.Reference exposing (Reference)
+import Code.Definition.Term as Term exposing (Term(..), TermCategory, TermDetail, TermSource)
+import Code.Definition.Type as Type exposing (Type(..), TypeCategory, TypeDetail, TypeSource)
+import Code.FullyQualifiedName as FQN exposing (FQN)
+import Code.Hash as Hash exposing (Hash)
+import Code.ProjectDependency as ProjectDependency exposing (ProjectDependency)
+import Json.Decode as Decode exposing (field, index)
+import Lib.Decode.Helpers as DecodeH
+import List.Nonempty as NEL
+import Maybe.Extra as MaybeE
+
+
+type alias WithDoc =
+    { doc : Maybe Doc }
+
+
+type alias TermDetailWithDoc =
+    TermDetail WithDoc
+
+
+type alias TypeDetailWithDoc =
+    TypeDetail WithDoc
+
+
+type DefinitionItem
+    = TermItem TermDetailWithDoc
+    | TypeItem TypeDetailWithDoc
+      -- TODO: DataConstructorItem and AbilityConstructorItem are currently not
+      -- rendered separate from TypeItem
+    | DataConstructorItem DataConstructorDetail
+    | AbilityConstructorItem AbilityConstructorDetail
+
+
+toLib : DefinitionItem -> Maybe ProjectDependency
+toLib defItem =
+    let
+        fqnToLib fqn =
+            case fqn |> FQN.segments |> NEL.toList of
+                "lib" :: _ :: "lib" :: _ ->
+                    Nothing
+
+                "lib" :: libName :: _ ->
+                    Just (ProjectDependency.fromString libName)
+
+                _ ->
+                    Nothing
+
+        toLib_ info_ =
+            case info_.namespace of
+                Just n ->
+                    fqnToLib n
+
+                Nothing ->
+                    let
+                        f n acc =
+                            if MaybeE.isJust acc then
+                                acc
+
+                            else
+                                fqnToLib n
+                    in
+                    List.foldl f Nothing info_.otherNames
+    in
+    defItem
+        |> info
+        |> toLib_
+
+
+name : DefinitionItem -> FQN
+name defItem =
+    defItem |> info |> .name
+
+
+hash : DefinitionItem -> Hash
+hash defItem =
+    case defItem of
+        TermItem (Term.Term h _ _) ->
+            h
+
+        TypeItem (Type.Type h _ _) ->
+            h
+
+        AbilityConstructorItem (AbilityConstructor h _) ->
+            h
+
+        DataConstructorItem (DataConstructor h _) ->
+            h
+
+
+isBuiltin : DefinitionItem -> Bool
+isBuiltin defItem =
+    case defItem of
+        TermItem t ->
+            Term.isBuiltin t
+
+        TypeItem t ->
+            Type.isBuiltin t
+
+        AbilityConstructorItem (AbilityConstructor.AbilityConstructor _ a) ->
+            Type.isBuiltinSource a.source
+
+        DataConstructorItem (DataConstructor.DataConstructor _ d) ->
+            Type.isBuiltinSource d.source
+
+
+isTerm : DefinitionItem -> Bool
+isTerm defItem =
+    case defItem of
+        TermItem _ ->
+            True
+
+        _ ->
+            False
+
+
+docs : DefinitionItem -> Maybe Doc
+docs defItem =
+    case defItem of
+        TermItem (Term.Term _ _ { doc }) ->
+            doc
+
+        TypeItem (Type.Type _ _ { doc }) ->
+            doc
+
+        _ ->
+            Nothing
+
+
+hasDocs : DefinitionItem -> Bool
+hasDocs defItem =
+    MaybeE.isJust (docs defItem)
+
+
+isDoc : DefinitionItem -> Bool
+isDoc defItem =
+    case defItem of
+        TermItem (Term.Term _ Term.DocTerm _) ->
+            True
+
+        _ ->
+            False
+
+
+info : DefinitionItem -> Info.Info
+info defItem =
+    case defItem of
+        TermItem (Term.Term _ _ details) ->
+            details.info
+
+        TypeItem (Type.Type _ _ details) ->
+            details.info
+
+        AbilityConstructorItem (AbilityConstructor _ details) ->
+            details.info
+
+        DataConstructorItem (DataConstructor _ details) ->
+            details.info
+
+
+namespace : DefinitionItem -> Maybe FQN
+namespace defItem =
+    defItem |> info |> .namespace
+
+
+otherNames : DefinitionItem -> List FQN
+otherNames defItem =
+    defItem |> info |> .otherNames
+
+
+
+-- JSON DECODERS
+
+
+decodeDocs : String -> Decode.Decoder (Maybe Doc)
+decodeDocs fieldName =
+    Decode.oneOf
+        [ Decode.map Just (field fieldName (index 0 (index 2 Doc.decode)))
+        , Decode.succeed Nothing
+        ]
+
+
+decodeTypeDetails :
+    Decode.Decoder
+        { category : TypeCategory
+        , name : FQN
+        , otherNames : NEL.Nonempty FQN
+        , source : TypeSource
+        , doc : Maybe Doc
+        }
+decodeTypeDetails =
+    let
+        make cat name_ otherNames_ source doc =
+            { category = cat
+            , doc = doc
+            , name = name_
+            , otherNames = otherNames_
+            , source = source
+            }
+    in
+    Decode.map5 make
+        (Type.decodeTypeCategory [ "defnTypeTag" ])
+        (field "bestTypeName" FQN.decode)
+        (field "typeNames" (DecodeH.nonEmptyList FQN.decode))
+        (Type.decodeTypeSource [ "typeDefinition", "tag" ] [ "typeDefinition", "contents" ])
+        (decodeDocs "typeDocs")
+
+
+decodeTypes : Reference -> Decode.Decoder (List TypeDetailWithDoc)
+decodeTypes ref =
+    let
+        makeType ( hash_, d ) =
+            hash_
+                |> Hash.fromString
+                |> Maybe.map
+                    (\h ->
+                        Type h
+                            d.category
+                            { doc = d.doc
+                            , info = Info.makeInfo ref d.name d.otherNames
+                            , source = d.source
+                            }
+                    )
+
+        buildTypes =
+            List.map makeType >> MaybeE.values
+    in
+    Decode.keyValuePairs decodeTypeDetails |> Decode.map buildTypes
+
+
+decodeTermDetails :
+    Decode.Decoder
+        { category : TermCategory
+        , name : FQN
+        , otherNames : NEL.Nonempty FQN
+        , source : TermSource
+        , doc : Maybe Doc
+        }
+decodeTermDetails =
+    let
+        make cat name_ otherNames_ source doc =
+            { category = cat
+            , name = name_
+            , otherNames = otherNames_
+            , source = source
+            , doc = doc
+            }
+    in
+    Decode.map5 make
+        (Term.decodeTermCategory [ "defnTermTag" ])
+        (field "bestTermName" FQN.decode)
+        (field "termNames" (DecodeH.nonEmptyList FQN.decode))
+        (Term.decodeTermSource
+            [ "termDefinition", "tag" ]
+            [ "signature" ]
+            [ "termDefinition", "contents" ]
+        )
+        (decodeDocs "termDocs")
+
+
+decodeTerms : Reference -> Decode.Decoder (List TermDetailWithDoc)
+decodeTerms ref =
+    let
+        makeTerm ( hash_, d ) =
+            hash_
+                |> Hash.fromString
+                |> Maybe.map
+                    (\h ->
+                        Term h
+                            d.category
+                            { doc = d.doc
+                            , info = Info.makeInfo ref d.name d.otherNames
+                            , source = d.source
+                            }
+                    )
+
+        buildTerms =
+            List.map makeTerm >> MaybeE.values
+    in
+    Decode.keyValuePairs decodeTermDetails |> Decode.map buildTerms
+
+
+{-| The server returns a list, but we only query for a single WorkspaceItem at a time.
+-}
+decodeList : Reference -> Decode.Decoder (List DefinitionItem)
+decodeList ref =
+    Decode.map2 List.append
+        (Decode.map (List.map TermItem) (field "termDefinitions" (decodeTerms ref)))
+        (Decode.map (List.map TypeItem) (field "typeDefinitions" (decodeTypes ref)))
+
+
+decode : Reference -> Decode.Decoder DefinitionItem
+decode ref =
+    Decode.map List.head (decodeList ref)
+        |> Decode.andThen
+            (Maybe.map Decode.succeed
+                >> Maybe.withDefault (Decode.fail "Empty list")
+            )

--- a/src/Code2/Workspace/DefinitionMatch.elm
+++ b/src/Code2/Workspace/DefinitionMatch.elm
@@ -1,0 +1,139 @@
+module Code2.Workspace.DefinitionMatch exposing (..)
+
+import Code.Definition.Term as Term exposing (TermCategory, TermSignature)
+import Code.Definition.Type as Type exposing (TypeCategory, TypeSource)
+import Code.FullyQualifiedName as FQN exposing (FQN)
+import Code.Hash as Hash exposing (Hash)
+import Json.Decode as Decode exposing (at, field)
+import Json.Decode.Extra exposing (when)
+import Json.Decode.Pipeline exposing (required, requiredAt)
+import Lib.Decode.Helpers exposing (whenKindIs)
+
+
+type alias MatchSummary cat sum =
+    { displayName : FQN
+    , fqn : FQN
+    , category : cat
+    , hash : Hash
+    , summary : sum
+    }
+
+
+type alias TermMatchSummary =
+    MatchSummary TermCategory TermSignature
+
+
+type alias TypeMatchSummary =
+    MatchSummary TypeCategory TypeSource
+
+
+type DefinitionMatch
+    = TermMatch TermMatchSummary
+    | TypeMatch TypeMatchSummary
+    | DataConstructorMatch TermMatchSummary
+    | AbilityConstructorMatch TermMatchSummary
+
+
+
+-- HELPERS
+
+
+displayName : DefinitionMatch -> FQN
+displayName defItem =
+    case defItem of
+        TermMatch sum ->
+            sum.displayName
+
+        TypeMatch sum ->
+            sum.displayName
+
+        DataConstructorMatch sum ->
+            sum.displayName
+
+        AbilityConstructorMatch sum ->
+            sum.displayName
+
+
+fqn : DefinitionMatch -> FQN
+fqn defItem =
+    case defItem of
+        TermMatch sum ->
+            sum.fqn
+
+        TypeMatch sum ->
+            sum.fqn
+
+        DataConstructorMatch sum ->
+            sum.fqn
+
+        AbilityConstructorMatch sum ->
+            sum.fqn
+
+
+
+-- JSON DECODERS
+
+
+decodeMatch_ :
+    (MatchSummary cat sum -> DefinitionMatch)
+    -> (List String -> Decode.Decoder cat)
+    -> Decode.Decoder sum
+    -> Decode.Decoder DefinitionMatch
+decodeMatch_ ctor catDecoder summaryDecoder =
+    let
+        make hash name_ fqn_ category summary =
+            ctor
+                { hash = hash
+                , fqn = fqn_
+                , displayName = name_
+                , category = category
+                , summary = summary
+                }
+    in
+    Decode.succeed make
+        |> requiredAt [ "definition", "hash" ] Hash.decode
+        |> requiredAt [ "definition", "displayName" ] FQN.decode
+        |> required "fqn" FQN.decode
+        |> requiredAt [ "definition" ] (catDecoder [ "tag" ])
+        |> requiredAt [ "definition", "summary" ] summaryDecoder
+
+
+decode : Decode.Decoder DefinitionMatch
+decode =
+    let
+        termTypeByHash hash =
+            if Hash.isAbilityConstructorHash hash then
+                "AbilityConstructor"
+
+            else if Hash.isDataConstructorHash hash then
+                "DataConstructor"
+
+            else
+                "Term"
+
+        decodeConstructorSuffix =
+            Decode.map termTypeByHash (at [ "definition", "hash" ] Hash.decode)
+
+        decodeTypeMatch =
+            decodeMatch_ TypeMatch Type.decodeTypeCategory (Type.decodeTypeSource [ "tag" ] [ "contents" ])
+
+        decodeTermMatch =
+            decodeMatch_ TermMatch Term.decodeTermCategory (Term.decodeSignature [ "contents" ])
+
+        decodeAbilityConstructorMatch =
+            decodeMatch_ TermMatch Term.decodeTermCategory (Term.decodeSignature [ "contents" ])
+
+        decodeDataConstructorMatch =
+            decodeMatch_ TermMatch Term.decodeTermCategory (Term.decodeSignature [ "contents" ])
+    in
+    Decode.oneOf
+        [ when decodeConstructorSuffix ((==) "AbilityConstructor") (field "definition" decodeAbilityConstructorMatch)
+        , when decodeConstructorSuffix ((==) "DataConstructor") (field "definition" decodeDataConstructorMatch)
+        , whenKindIs "term" decodeTermMatch
+        , whenKindIs "type" decodeTypeMatch
+        ]
+
+
+decodeList : Decode.Decoder (List DefinitionMatch)
+decodeList =
+    Decode.list decode

--- a/src/Code2/Workspace/DefinitionWorkspaceItemState.elm
+++ b/src/Code2/Workspace/DefinitionWorkspaceItemState.elm
@@ -1,0 +1,25 @@
+module Code2.Workspace.DefinitionWorkspaceItemState exposing (..)
+
+import Code.Definition.Doc as Doc exposing (DocFoldToggles)
+
+
+type DefinitionItemTab
+    = CodeTab
+    | DocsTab
+
+
+type alias DefinitionWorkspaceItemState =
+    { activeTab : DefinitionItemTab
+    , namespaceDropdownIsOpen : Bool
+    , docFoldToggles : DocFoldToggles
+    , isCodeFolded : Bool
+    }
+
+
+init : DefinitionItemTab -> DefinitionWorkspaceItemState
+init tab =
+    { activeTab = tab
+    , namespaceDropdownIsOpen = False
+    , docFoldToggles = Doc.emptyDocFoldToggles
+    , isCodeFolded = True
+    }

--- a/src/Code2/Workspace/DependentsWorkspaceItemState.elm
+++ b/src/Code2/Workspace/DependentsWorkspaceItemState.elm
@@ -1,0 +1,20 @@
+module Code2.Workspace.DependentsWorkspaceItemState exposing (..)
+
+
+type DependentsItemTab
+    = TermsTab
+    | TypesTab
+    | AbilitiesTab
+    | DocsTab
+    | TestsTab
+
+
+type alias DependentsWorkspaceItemState =
+    { activeTab : DependentsItemTab
+    , searchQuery : String
+    }
+
+
+init : DependentsItemTab -> DependentsWorkspaceItemState
+init tab =
+    { activeTab = tab, searchQuery = "" }

--- a/src/Code2/Workspace/WorkspaceCard.elm
+++ b/src/Code2/Workspace/WorkspaceCard.elm
@@ -1,0 +1,322 @@
+module Code2.Workspace.WorkspaceCard exposing (..)
+
+import Code.ProjectDependency as ProjectDependency exposing (ProjectDependency)
+import Code2.Workspace.WorkspaceCardTitlebarButton as TitlebarButton exposing (titlebarButton)
+import Html exposing (Html, div, header, section, span, text)
+import Html.Attributes exposing (class)
+import Lib.OperatingSystem exposing (OperatingSystem)
+import UI
+import UI.Card as Card
+import UI.Click as Click exposing (Click)
+import UI.ContextualTag as ContextualTag
+import UI.Icon as Icon exposing (Icon)
+import UI.KeyboardShortcut as KeyboardShortcut exposing (KeyboardShortcut(..), single)
+import UI.KeyboardShortcut.Key as Key exposing (letter)
+import UI.TabList as TabList exposing (TabList)
+
+
+type alias WorkspaceCard msg =
+    { titleLeft : List (Html msg)
+    , titleRight : List (Html msg)
+    , subtitleBar : Maybe (Html msg)
+    , tabList : Maybe (TabList msg)
+    , content : List (Html msg)
+    , hasFocus : Bool
+    , domId : Maybe String
+    , click : Click msg
+    , close : Maybe msg
+    , isFolded : Bool
+    , toggleFold : Maybe msg
+    , className : String
+    }
+
+
+
+-- CREATE
+
+
+empty : WorkspaceCard msg
+empty =
+    { titleLeft = []
+    , titleRight = []
+    , subtitleBar = Nothing
+    , tabList = Nothing
+    , content = []
+    , hasFocus = False
+    , domId = Nothing
+    , click = Click.disabled
+    , close = Nothing
+    , isFolded = False
+    , toggleFold = Nothing
+    , className = ""
+    }
+
+
+card : List (Html msg) -> WorkspaceCard msg
+card content =
+    empty
+        |> withContent content
+
+
+
+-- MODIFY
+
+
+withTitle : String -> WorkspaceCard msg -> WorkspaceCard msg
+withTitle title card_ =
+    { card_
+        | titleLeft =
+            [ span [ class "workspace-card_title" ] [ text title ] ]
+    }
+
+
+withClassName : String -> WorkspaceCard msg -> WorkspaceCard msg
+withClassName className card_ =
+    { card_ | className = className }
+
+
+withTitlebar : { left : List (Html msg), right : List (Html msg) } -> WorkspaceCard msg -> WorkspaceCard msg
+withTitlebar { left, right } card_ =
+    { card_ | titleLeft = left, titleRight = right }
+
+
+withTitlebarLeft : List (Html msg) -> WorkspaceCard msg -> WorkspaceCard msg
+withTitlebarLeft left card_ =
+    { card_ | titleLeft = left }
+
+
+withTitlebarRight : List (Html msg) -> WorkspaceCard msg -> WorkspaceCard msg
+withTitlebarRight right card_ =
+    { card_ | titleRight = right }
+
+
+withSubtitle : String -> WorkspaceCard msg -> WorkspaceCard msg
+withSubtitle subtitle card_ =
+    withSubtitleBar (span [ class "subdued" ] [ text subtitle ]) card_
+
+
+withSubtitleBar : Html msg -> WorkspaceCard msg -> WorkspaceCard msg
+withSubtitleBar subtitle card_ =
+    { card_ | subtitleBar = Just subtitle }
+
+
+withContent : List (Html msg) -> WorkspaceCard msg -> WorkspaceCard msg
+withContent content card_ =
+    { card_ | content = content }
+
+
+withDomId : String -> WorkspaceCard msg -> WorkspaceCard msg
+withDomId domId card_ =
+    { card_ | domId = Just domId }
+
+
+withClick : Click msg -> WorkspaceCard msg -> WorkspaceCard msg
+withClick click card_ =
+    { card_ | click = click }
+
+
+withClose : msg -> WorkspaceCard msg -> WorkspaceCard msg
+withClose close card_ =
+    { card_ | close = Just close }
+
+
+withToggleFold : msg -> WorkspaceCard msg -> WorkspaceCard msg
+withToggleFold toggleFold card_ =
+    { card_ | toggleFold = Just toggleFold }
+
+
+withIsFolded : Bool -> WorkspaceCard msg -> WorkspaceCard msg
+withIsFolded isFolded card_ =
+    { card_ | isFolded = isFolded }
+
+
+fold : WorkspaceCard msg -> WorkspaceCard msg
+fold card_ =
+    { card_ | isFolded = True }
+
+
+unfold : WorkspaceCard msg -> WorkspaceCard msg
+unfold card_ =
+    { card_ | isFolded = False }
+
+
+withTabList : TabList msg -> WorkspaceCard msg -> WorkspaceCard msg
+withTabList tabList card_ =
+    { card_ | tabList = Just tabList }
+
+
+withFocus : Bool -> WorkspaceCard msg -> WorkspaceCard msg
+withFocus hasFocus card_ =
+    { card_ | hasFocus = hasFocus }
+
+
+focus : WorkspaceCard msg -> WorkspaceCard msg
+focus card_ =
+    { card_ | hasFocus = True }
+
+
+blur : WorkspaceCard msg -> WorkspaceCard msg
+blur card_ =
+    { card_ | hasFocus = False }
+
+
+
+-- MAP
+
+
+map : (fromMsg -> toMsg) -> WorkspaceCard fromMsg -> WorkspaceCard toMsg
+map f card_ =
+    let
+        map_ =
+            List.map (Html.map f)
+    in
+    { titleLeft = map_ card_.titleLeft
+    , titleRight = map_ card_.titleRight
+    , subtitleBar = Maybe.map (Html.map f) card_.subtitleBar
+    , tabList = Maybe.map (TabList.map f) card_.tabList
+    , content = map_ card_.content
+    , hasFocus = card_.hasFocus
+    , domId = card_.domId
+    , click = Click.map f card_.click
+    , close = Maybe.map f card_.close
+    , isFolded = card_.isFolded
+    , toggleFold = Maybe.map f card_.toggleFold
+    , className = card_.className
+    }
+
+
+
+-- RELATED VIEW HELPERS
+
+
+viewLibraryTag : ProjectDependency -> Html msg
+viewLibraryTag dep =
+    ContextualTag.contextualTag Icon.book (ProjectDependency.toString dep)
+        |> ContextualTag.decorativePurple
+        |> ContextualTag.withTooltipText "Library dependency"
+        |> ContextualTag.view
+
+
+
+-- VIEW
+
+
+toggleFoldedIcon : Bool -> Icon msg
+toggleFoldedIcon isFolded =
+    if isFolded then
+        Icon.collapseUp
+
+    else
+        Icon.expandDown
+
+
+consIf : a -> Bool -> List a -> List a
+consIf x isTrue xs =
+    if isTrue then
+        x :: xs
+
+    else
+        xs
+
+
+view : OperatingSystem -> WorkspaceCard msg -> Html msg
+view os wsCard =
+    let
+        { titleLeft, titleRight, subtitleBar, tabList, content, hasFocus, domId, click, close, isFolded, toggleFold } =
+            wsCard
+
+        className =
+            [ "workspace-card", wsCard.className ]
+                |> consIf "focused" hasFocus
+                |> consIf "folded" isFolded
+                |> String.join " "
+
+        close_ =
+            case close of
+                Nothing ->
+                    []
+
+                Just closeMsg ->
+                    [ titlebarButton closeMsg
+                        Icon.x
+                        |> TitlebarButton.withLeftOfTooltip
+                            (div [ class "tooltip-with-shortcut" ]
+                                [ text "Close"
+                                , KeyboardShortcut.viewSimple os (single (letter Key.X))
+                                , text "Close all:"
+                                , KeyboardShortcut.viewSimple os (Chord Key.Shift (letter Key.X))
+                                ]
+                            )
+                        |> TitlebarButton.view
+                    ]
+
+        toggleFold_ =
+            case toggleFold of
+                Nothing ->
+                    []
+
+                Just toggle ->
+                    [ titlebarButton toggle
+                        (toggleFoldedIcon isFolded)
+                        |> TitlebarButton.withLeftOfTooltip
+                            (div [ class "tooltip-with-shortcut" ]
+                                [ text "Toggle fold"
+                                , KeyboardShortcut.viewSimple os (single (letter Key.Z))
+                                , text "Toggle all:"
+                                , KeyboardShortcut.viewSimple os (Chord Key.Shift (letter Key.Z))
+                                ]
+                            )
+                        |> TitlebarButton.view
+                    ]
+
+        titleRight_ =
+            div [ class "workspace-card_titlebar_right" ] (titleRight ++ toggleFold_ ++ close_)
+
+        titlebar =
+            header [ class "workspace-card_titlebar" ]
+                [ div [ class "workspace-card_titlebar_left" ] titleLeft
+                , titleRight_
+                ]
+
+        subtitleBar_ =
+            case subtitleBar of
+                Just stb ->
+                    div [ class "workspace-card_subtitlebar" ] [ stb ]
+
+                Nothing ->
+                    UI.nothing
+
+        cardContent =
+            [ titlebar
+            , subtitleBar_
+            , div [ class "workspace-card_foldable-content" ]
+                [ tabList |> Maybe.map TabList.view |> Maybe.withDefault UI.nothing
+                , section [ class "workspace-card_main-content" ] content
+                ]
+            ]
+
+        card_ =
+            case domId of
+                Just domId_ ->
+                    Card.card cardContent
+                        |> Card.withDomId domId_
+
+                Nothing ->
+                    Card.card cardContent
+
+        html =
+            card_
+                |> Card.asContained
+                |> Card.withClassName className
+                |> Card.view
+    in
+    case click of
+        Click.Disabled ->
+            html
+
+        _ ->
+            if hasFocus then
+                html
+
+            else
+                Click.view [] [ html ] click

--- a/src/Code2/Workspace/WorkspaceCardTitlebarButton.elm
+++ b/src/Code2/Workspace/WorkspaceCardTitlebarButton.elm
@@ -1,0 +1,63 @@
+module Code2.Workspace.WorkspaceCardTitlebarButton exposing (..)
+
+import Html exposing (Html)
+import UI.Button as Button
+import UI.Icon exposing (Icon)
+import UI.Tooltip as Tooltip
+
+
+type TitlebarTooltip msg
+    = NoTooltip
+    | LeftOf (Html msg)
+    | RightOf (Html msg)
+
+
+type alias TitlebarButton msg =
+    { icon : Icon msg
+    , onClick : msg
+    , tooltip : TitlebarTooltip msg
+    }
+
+
+titlebarButton : msg -> Icon msg -> TitlebarButton msg
+titlebarButton onClick icon =
+    { onClick = onClick, icon = icon, tooltip = NoTooltip }
+
+
+withLeftOfTooltip : Html msg -> TitlebarButton msg -> TitlebarButton msg
+withLeftOfTooltip content titlebarButton_ =
+    { titlebarButton_ | tooltip = LeftOf content }
+
+
+withRightOfTooltip : Html msg -> TitlebarButton msg -> TitlebarButton msg
+withRightOfTooltip content titlebarButton_ =
+    { titlebarButton_ | tooltip = RightOf content }
+
+
+view : TitlebarButton msg -> Html msg
+view { icon, onClick, tooltip } =
+    let
+        button =
+            Button.icon onClick icon
+                |> Button.stopPropagation
+                |> Button.subdued
+                |> Button.small
+                |> Button.view
+    in
+    case tooltip of
+        NoTooltip ->
+            button
+
+        LeftOf tooltipContent ->
+            Tooltip.rich tooltipContent
+                |> Tooltip.tooltip
+                |> Tooltip.below
+                |> Tooltip.withArrow Tooltip.End
+                |> Tooltip.view button
+
+        RightOf tooltipContent ->
+            Tooltip.rich tooltipContent
+                |> Tooltip.tooltip
+                |> Tooltip.below
+                |> Tooltip.withArrow Tooltip.Start
+                |> Tooltip.view button

--- a/src/Code2/Workspace/WorkspaceContext.elm
+++ b/src/Code2/Workspace/WorkspaceContext.elm
@@ -1,0 +1,33 @@
+port module Code2.Workspace.WorkspaceContext exposing (WorkspaceContext, decode, save)
+
+import Code.BranchRef as BranchRef
+import Code.ProjectName as ProjectName exposing (ProjectName)
+import Json.Decode as Decode
+import Json.Decode.Pipeline exposing (required)
+import Json.Encode as Encode
+
+
+type alias WorkspaceContext =
+    { projectName : ProjectName, branchRef : BranchRef.BranchRef }
+
+
+save : WorkspaceContext -> Cmd msg
+save context =
+    let
+        json =
+            Encode.object
+                [ ( "projectName", context.projectName |> ProjectName.toString |> Encode.string )
+                , ( "branchRef", context.branchRef |> BranchRef.toString |> Encode.string )
+                ]
+    in
+    saveWorkspaceContext json
+
+
+port saveWorkspaceContext : Encode.Value -> Cmd msg
+
+
+decode : Decode.Decoder WorkspaceContext
+decode =
+    Decode.succeed WorkspaceContext
+        |> required "projectName" ProjectName.decode
+        |> required "branchRef" BranchRef.decode

--- a/src/Code2/Workspace/WorkspaceDefinitionItemCard.elm
+++ b/src/Code2/Workspace/WorkspaceDefinitionItemCard.elm
@@ -1,0 +1,383 @@
+module Code2.Workspace.WorkspaceDefinitionItemCard exposing (..)
+
+import Code.Definition.Doc as Doc
+import Code.Definition.Reference exposing (Reference)
+import Code.Definition.Source as Source
+import Code.Definition.Term as Term
+import Code.Definition.Type as Type
+import Code.FullyQualifiedName as FQN exposing (FQN)
+import Code.Hash as Hash
+import Code.Source.SourceViewConfig as SourceViewConfig
+import Code.Syntax.SyntaxConfig as SyntaxConfig
+import Code2.Workspace.DefinitionItem as DefinitionItem exposing (DefinitionItem(..))
+import Code2.Workspace.DefinitionWorkspaceItemState exposing (DefinitionItemTab(..), DefinitionWorkspaceItemState)
+import Code2.Workspace.WorkspaceCard as WorkspaceCard exposing (WorkspaceCard)
+import Code2.Workspace.WorkspaceCardTitlebarButton as TitlebarButton exposing (titlebarButton)
+import Code2.Workspace.WorkspaceItemRef exposing (WorkspaceItemRef)
+import Html exposing (Html, div, text)
+import Html.Attributes exposing (class)
+import UI
+import UI.ActionMenu as ActionMenu
+import UI.Button as Button
+import UI.Click as Click
+import UI.CopyOnClick as CopyOnClick
+import UI.Divider as Divider
+import UI.FoldToggle as FoldToggle
+import UI.Icon as Icon exposing (Icon)
+import UI.TabList as TabList
+import UI.Tag as Tag
+import UI.Tooltip as Tooltip
+
+
+type alias NamespaceDropdown msg =
+    { toggle : msg
+    , findWithinNamespace : FQN -> msg
+    , changePerspective : FQN -> msg
+    }
+
+
+type CodeAndDocsViewMode msg
+    = WithTabs { changeTab : DefinitionItemTab -> msg }
+    | MixedCodeAndDocs { toggleCodeFold : msg }
+
+
+type alias WorkspaceDefinitionItemCardConfig msg =
+    { wsRef : WorkspaceItemRef
+    , definitionRef : Reference
+    , toggleDocFold : Doc.FoldId -> msg
+    , closeItem : msg
+    , isFolded : Bool
+    , toggleFold : msg
+    , state : DefinitionWorkspaceItemState
+    , item : DefinitionItem
+    , codeAndDocsViewMode : CodeAndDocsViewMode msg
+    , syntaxConfig : SyntaxConfig.SyntaxConfig msg
+    , showDependents : msg
+    , withDependents : Bool
+    , withDependencies : Bool
+    , namespaceDropdown : Maybe (NamespaceDropdown msg)
+    }
+
+
+rawSource : DefinitionItem -> Maybe String
+rawSource defItem =
+    case defItem of
+        TermItem detail ->
+            Term.rawSource detail
+
+        TypeItem detail ->
+            Type.rawSource detail
+
+        _ ->
+            Nothing
+
+
+viewDefinitionItemSource : WorkspaceDefinitionItemCardConfig msg -> Html msg
+viewDefinitionItemSource cfg =
+    let
+        sourceViewConfig =
+            SourceViewConfig.rich cfg.syntaxConfig
+
+        source_ =
+            case cfg.item of
+                TermItem (Term.Term _ _ { info, source }) ->
+                    let
+                        fullSource =
+                            Source.viewTermSource sourceViewConfig info.name source
+                    in
+                    case cfg.codeAndDocsViewMode of
+                        MixedCodeAndDocs { toggleCodeFold } ->
+                            let
+                                viewFoldableSource renderedSource =
+                                    div [ class "foldable-source" ]
+                                        [ FoldToggle.view foldToggle, renderedSource ]
+
+                                foldToggle =
+                                    FoldToggle.foldToggle toggleCodeFold
+                                        |> FoldToggle.isOpen (not cfg.state.isCodeFolded)
+
+                                signature =
+                                    Source.viewNamedTermSignature sourceViewConfig info.name (Term.termSignature source)
+
+                                foldedOrUnfoldedSource =
+                                    if cfg.state.isCodeFolded then
+                                        signature
+
+                                    else
+                                        fullSource
+                            in
+                            if DefinitionItem.isBuiltin cfg.item || not (DefinitionItem.hasDocs cfg.item) then
+                                fullSource
+
+                            else
+                                viewFoldableSource foldedOrUnfoldedSource
+
+                        _ ->
+                            fullSource
+
+                TypeItem (Type.Type _ _ { source }) ->
+                    Source.viewTypeSource sourceViewConfig source
+
+                _ ->
+                    UI.nothing
+    in
+    div [ class "definition-source" ] [ source_ ]
+
+
+definitionItemTabs : (DefinitionItemTab -> msg) -> { code : TabList.Tab msg, docs : TabList.Tab msg }
+definitionItemTabs changeTab =
+    { code =
+        TabList.tab "Code"
+            (Click.onClick (changeTab CodeTab))
+    , docs =
+        TabList.tab "Docs"
+            (Click.onClick (changeTab DocsTab))
+    }
+
+
+categoryIcon : DefinitionItem -> Icon msg
+categoryIcon item =
+    case item of
+        TermItem (Term.Term _ cat _) ->
+            case cat of
+                Term.PlainTerm ->
+                    Icon.term
+
+                Term.DocTerm ->
+                    Icon.doc
+
+                Term.TestTerm ->
+                    Icon.test
+
+        TypeItem (Type.Type _ cat _) ->
+            case cat of
+                Type.DataType ->
+                    Icon.type_
+
+                Type.AbilityType ->
+                    Icon.ability
+
+        AbilityConstructorItem _ ->
+            Icon.abilityConstructor
+
+        DataConstructorItem _ ->
+            Icon.dataConstructor
+
+
+viewItemContent : WorkspaceDefinitionItemCardConfig msg -> Html msg
+viewItemContent cfg =
+    case cfg.codeAndDocsViewMode of
+        WithTabs _ ->
+            case ( cfg.state.activeTab, DefinitionItem.docs cfg.item ) of
+                ( DocsTab, Just docs ) ->
+                    Doc.view cfg.syntaxConfig
+                        cfg.toggleDocFold
+                        cfg.state.docFoldToggles
+                        docs
+
+                _ ->
+                    viewDefinitionItemSource cfg
+
+        MixedCodeAndDocs _ ->
+            case DefinitionItem.docs cfg.item of
+                Just docs ->
+                    let
+                        sourceAndDivider =
+                            if not (DefinitionItem.isBuiltin cfg.item) || DefinitionItem.isTerm cfg.item then
+                                [ viewDefinitionItemSource cfg
+                                , Divider.viewSimple
+                                ]
+
+                            else
+                                []
+                    in
+                    div [ class "mixed-docs-and-code" ]
+                        (sourceAndDivider
+                            ++ [ Doc.view cfg.syntaxConfig
+                                    cfg.toggleDocFold
+                                    cfg.state.docFoldToggles
+                                    docs
+                               ]
+                        )
+
+                _ ->
+                    viewDefinitionItemSource cfg
+
+
+viewNamespaceDropdown : WorkspaceDefinitionItemCardConfig msg -> Html msg
+viewNamespaceDropdown cfg =
+    case ( cfg.namespaceDropdown, DefinitionItem.namespace cfg.item ) of
+        ( Just dropdown, Just fqn ) ->
+            let
+                ns =
+                    FQN.toString fqn
+            in
+            div [ class "namespace-dropdown" ]
+                [ ActionMenu.items
+                    (ActionMenu.optionItem
+                        Icon.browse
+                        ("Find within " ++ ns)
+                        (Click.onClick (dropdown.findWithinNamespace fqn))
+                    )
+                    [ ActionMenu.optionItem
+                        Icon.intoFolder
+                        ("Change perspective to " ++ ns)
+                        (Click.onClick (dropdown.changePerspective fqn))
+                    ]
+                    |> ActionMenu.fromButton dropdown.toggle ns
+                    |> ActionMenu.extendingRight
+                    |> ActionMenu.withButtonColor Button.Outlined
+                    |> ActionMenu.shouldBeOpen cfg.state.namespaceDropdownIsOpen
+                    |> ActionMenu.view
+                ]
+
+        _ ->
+            UI.nothing
+
+
+titlebarLeft : WorkspaceDefinitionItemCardConfig msg -> List (Html msg)
+titlebarLeft cfg =
+    let
+        lib =
+            cfg.item
+                |> DefinitionItem.toLib
+                |> Maybe.map WorkspaceCard.viewLibraryTag
+                |> Maybe.withDefault UI.nothing
+
+        copySourceToClipboard =
+            case rawSource cfg.item of
+                Just source ->
+                    div [ class "copy-code" ]
+                        [ Tooltip.tooltip (Tooltip.text "Copy source")
+                            |> Tooltip.below
+                            |> Tooltip.withArrow Tooltip.Start
+                            |> Tooltip.view
+                                (CopyOnClick.view source
+                                    (div [ class "button small subdued content-icon" ]
+                                        [ Icon.view Icon.clipboard ]
+                                    )
+                                    (Icon.view Icon.checkmark)
+                                )
+                        ]
+
+                Nothing ->
+                    UI.nothing
+
+        builtin =
+            if DefinitionItem.isBuiltin cfg.item then
+                Tooltip.tooltip
+                    (Tooltip.text
+                        (FQN.toString (DefinitionItem.name cfg.item) ++ " is a built-in definition provided by the Unison runtime.")
+                    )
+                    |> Tooltip.below
+                    |> Tooltip.withArrow Tooltip.Start
+                    |> Tooltip.view
+                        (Tag.tag "Built-in"
+                            |> Tag.withIcon Icon.unisonMark
+                            |> Tag.view
+                        )
+
+            else
+                UI.nothing
+    in
+    [ div [ class "category-icon" ] [ Icon.view (categoryIcon cfg.item) ]
+    , lib
+    , viewNamespaceDropdown cfg
+    , FQN.view (DefinitionItem.name cfg.item)
+    , builtin
+    , copySourceToClipboard
+    ]
+
+
+titlebarRight : WorkspaceDefinitionItemCardConfig msg -> List (Html msg)
+titlebarRight cfg =
+    let
+        defHash =
+            div [ class "definition-hash" ]
+                [ Tooltip.tooltip (Tooltip.text "Copy full definition hash")
+                    |> Tooltip.below
+                    |> Tooltip.withArrow Tooltip.End
+                    |> Tooltip.view
+                        (CopyOnClick.view (Hash.toUnprefixedString (DefinitionItem.hash cfg.item))
+                            (Hash.view (DefinitionItem.hash cfg.item))
+                            (Icon.view Icon.checkmark)
+                        )
+                ]
+
+        dependentsButton =
+            -- Feature flag dependents (which aren't ready in UCM yet, but exist in Share)
+            if cfg.withDependents then
+                titlebarButton cfg.showDependents Icon.dependents
+                    |> TitlebarButton.withLeftOfTooltip (text "View direct dependents")
+                    |> TitlebarButton.view
+
+            else
+                UI.nothing
+
+        otherNames_ =
+            DefinitionItem.otherNames cfg.item
+
+        otherNames =
+            if not (List.isEmpty otherNames_) then
+                let
+                    viewOtherName n =
+                        div [ class "other-name" ]
+                            [ Icon.view Icon.boldDot
+                            , div [ class "fully-qualified-name" ] [ FQN.view n ]
+                            ]
+
+                    otherNamesTooltipContent =
+                        Tooltip.rich
+                            (div [ class "workspace-definition-item-card_other-names_list" ]
+                                (div [ class "aka" ] [ text "Also known as" ] :: List.map viewOtherName otherNames_)
+                            )
+                in
+                div [ class "workspace-definition-item-card_other-names" ]
+                    [ Tooltip.tooltip otherNamesTooltipContent
+                        |> Tooltip.below
+                        |> Tooltip.withArrow Tooltip.End
+                        |> Tooltip.view (div [ class "workspace-definition-item-card_other-names_button" ] [ Icon.view Icon.tags ])
+                    ]
+
+            else
+                UI.nothing
+    in
+    [ defHash
+    , otherNames
+    , dependentsButton
+    ]
+
+
+view : WorkspaceDefinitionItemCardConfig msg -> WorkspaceCard msg
+view cfg =
+    let
+        withTabList c =
+            case cfg.codeAndDocsViewMode of
+                WithTabs { changeTab } ->
+                    let
+                        tabs =
+                            definitionItemTabs changeTab
+                    in
+                    if DefinitionItem.hasDocs cfg.item then
+                        case cfg.state.activeTab of
+                            CodeTab ->
+                                c |> WorkspaceCard.withTabList (TabList.tabList [] tabs.code [ tabs.docs ])
+
+                            DocsTab ->
+                                c |> WorkspaceCard.withTabList (TabList.tabList [ tabs.code ] tabs.docs [])
+
+                    else
+                        c
+
+                _ ->
+                    c
+    in
+    WorkspaceCard.empty
+        |> WorkspaceCard.withClassName "workspace-definition-item-card"
+        |> WorkspaceCard.withTitlebarLeft (titlebarLeft cfg)
+        |> WorkspaceCard.withTitlebarRight (titlebarRight cfg)
+        |> WorkspaceCard.withClose cfg.closeItem
+        |> WorkspaceCard.withToggleFold cfg.toggleFold
+        |> WorkspaceCard.withIsFolded cfg.isFolded
+        |> withTabList
+        |> WorkspaceCard.withContent [ viewItemContent cfg ]

--- a/src/Code2/Workspace/WorkspaceDependentsItemCard.elm
+++ b/src/Code2/Workspace/WorkspaceDependentsItemCard.elm
@@ -1,0 +1,405 @@
+module Code2.Workspace.WorkspaceDependentsItemCard exposing (..)
+
+import Code.Definition.Reference as Reference exposing (Reference)
+import Code.Definition.Term as Term exposing (Term(..))
+import Code.Definition.Type as Type exposing (Type(..))
+import Code.DefinitionSummaryTooltip as DefinitionSummaryTooltip
+import Code.FullyQualifiedName as FQN
+import Code.Syntax.SyntaxSegment as SyntaxSegment
+import Code2.Workspace.DefinitionItem as DefinitionItem exposing (DefinitionItem)
+import Code2.Workspace.DefinitionMatch as DefinitionMatch exposing (DefinitionMatch(..))
+import Code2.Workspace.DependentsWorkspaceItemState exposing (DependentsItemTab(..), DependentsWorkspaceItemState)
+import Code2.Workspace.WorkspaceCard as WorkspaceCard exposing (WorkspaceCard)
+import Code2.Workspace.WorkspaceItemRef exposing (WorkspaceItemRef)
+import Html exposing (Html, div, strong, text)
+import Html.Attributes exposing (class)
+import Lib.String.Helpers exposing (pluralize)
+import Maybe.Extra as MaybeE
+import RemoteData
+import UI
+import UI.Click as Click
+import UI.Form.TextField as TextField
+import UI.Icon as Icon
+import UI.TabList as TabList exposing (tab, tabList)
+import UI.Tooltip as Tooltip
+
+
+type alias ViewConfig msg =
+    { wsRef : WorkspaceItemRef
+    , dependentsOfRef : Reference
+    , item : DefinitionItem
+    , dependents : List DefinitionMatch
+    , updateQuery : String -> msg
+    , closeItem : msg
+    , openDefinition : Reference -> msg
+    , state : DependentsWorkspaceItemState
+    , changeTab : DependentsItemTab -> msg
+    }
+
+
+type alias GroupedDependents =
+    { terms : List DefinitionMatch
+    , types : List DefinitionMatch
+    , abilities : List DefinitionMatch
+    , tests : List DefinitionMatch
+    , docs : List DefinitionMatch
+    }
+
+
+groupDependents : List DefinitionMatch -> GroupedDependents
+groupDependents dependents =
+    let
+        f dep acc =
+            case dep of
+                TermMatch { category } ->
+                    case category of
+                        Term.PlainTerm ->
+                            { acc | terms = dep :: acc.terms }
+
+                        Term.TestTerm ->
+                            { acc | tests = dep :: acc.tests }
+
+                        Term.DocTerm ->
+                            { acc | docs = dep :: acc.docs }
+
+                TypeMatch { category } ->
+                    case category of
+                        Type.DataType ->
+                            { acc | types = dep :: acc.types }
+
+                        Type.AbilityType ->
+                            { acc | abilities = dep :: acc.abilities }
+
+                AbilityConstructorMatch _ ->
+                    { acc | abilities = dep :: acc.abilities }
+
+                DataConstructorMatch _ ->
+                    { acc | types = dep :: acc.types }
+    in
+    List.foldl f { terms = [], types = [], abilities = [], docs = [], tests = [] } dependents
+
+
+viewDependent : (Reference -> msg) -> DefinitionMatch -> Html msg
+viewDependent openDefinition match =
+    let
+        ( name, ref, defSum ) =
+            case match of
+                TermMatch { displayName, hash, category, fqn, summary } ->
+                    let
+                        termSum =
+                            Term hash
+                                category
+                                { fqn = fqn
+                                , name = displayName
+                                , namespace = Nothing
+                                , signature = summary
+                                }
+                    in
+                    ( displayName
+                    , Reference.fromFQN Reference.TermReference fqn
+                    , DefinitionSummaryTooltip.TermHover termSum
+                    )
+
+                TypeMatch { hash, category, summary, displayName, fqn } ->
+                    let
+                        typeSum =
+                            Type hash
+                                category
+                                { fqn = fqn
+                                , name = displayName
+                                , namespace = Nothing
+                                , source = summary
+                                }
+                    in
+                    ( displayName
+                    , Reference.fromFQN Reference.TypeReference fqn
+                    , DefinitionSummaryTooltip.TypeHover typeSum
+                    )
+
+                DataConstructorMatch { hash, category, summary, displayName, fqn } ->
+                    let
+                        termSum =
+                            Term hash
+                                category
+                                { fqn = fqn
+                                , name = displayName
+                                , namespace = Nothing
+                                , signature = summary
+                                }
+                    in
+                    ( displayName
+                    , Reference.fromFQN Reference.TypeReference fqn
+                    , DefinitionSummaryTooltip.TermHover termSum
+                    )
+
+                AbilityConstructorMatch { hash, category, summary, displayName, fqn } ->
+                    let
+                        termSum =
+                            Term hash
+                                category
+                                { fqn = fqn
+                                , name = displayName
+                                , namespace = Nothing
+                                , signature = summary
+                                }
+                    in
+                    ( displayName
+                    , Reference.fromFQN Reference.TypeReference fqn
+                    , DefinitionSummaryTooltip.TermHover termSum
+                    )
+
+        tooltipContent =
+            DefinitionSummaryTooltip.viewSummary (RemoteData.Success defSum)
+
+        content =
+            case tooltipContent of
+                Just c ->
+                    c
+                        |> Tooltip.tooltip
+                        |> Tooltip.below
+                        |> Tooltip.withArrow Tooltip.Start
+                        |> Tooltip.view
+                            (SyntaxSegment.viewFQN name)
+
+                Nothing ->
+                    SyntaxSegment.viewFQN name
+    in
+    Click.onClick (openDefinition ref)
+        |> Click.stopPropagation
+        |> Click.view [ class "dependent fqn" ] [ content ]
+
+
+viewDependents : String -> (Reference -> msg) -> List DefinitionMatch -> Html msg
+viewDependents className openDefinition dependents =
+    let
+        dependents_ =
+            dependents
+                |> List.sortBy (DefinitionMatch.displayName >> FQN.toString >> String.toLower)
+                |> List.map (viewDependent openDefinition)
+    in
+    div [ class "dependents_column rich" ]
+        [ div [ class ("dependents_items syntax " ++ className) ]
+            dependents_
+        ]
+
+
+blankIfEmpty : Html msg -> List a -> Html msg
+blankIfEmpty html xs =
+    if List.isEmpty xs then
+        UI.nothing
+
+    else
+        html
+
+
+dependentsItemTab :
+    (DependentsItemTab -> msg)
+    -> GroupedDependents
+    ->
+        { terms : Maybe (TabList.Tab msg)
+        , types : Maybe (TabList.Tab msg)
+        , abilities : Maybe (TabList.Tab msg)
+        , docs : Maybe (TabList.Tab msg)
+        , tests : Maybe (TabList.Tab msg)
+        }
+dependentsItemTab changeTab group =
+    let
+        mkTab title msg dependents =
+            if List.isEmpty dependents then
+                Nothing
+
+            else
+                Just (tab title (Click.onClick (changeTab msg)) |> TabList.withCount (List.length dependents))
+    in
+    { terms = mkTab "Terms" TermsTab group.terms
+    , types = mkTab "Types" TypesTab group.types
+    , abilities = mkTab "Abilities" AbilitiesTab group.abilities
+    , docs = mkTab "Docs" DocsTab group.docs
+    , tests = mkTab "Tests" TestsTab group.tests
+    }
+
+
+withTabList : ViewConfig msg -> GroupedDependents -> WorkspaceCard msg -> WorkspaceCard msg
+withTabList cfg group card =
+    let
+        tabs =
+            dependentsItemTab cfg.changeTab group
+
+        tabOrCard before tab_ after =
+            case tab_ of
+                Just t ->
+                    card
+                        |> WorkspaceCard.withTabList
+                            (tabList (MaybeE.values before) t (MaybeE.values after))
+
+                Nothing ->
+                    card
+    in
+    if isSearching cfg then
+        card
+
+    else
+        case cfg.state.activeTab of
+            TermsTab ->
+                tabOrCard [] tabs.terms [ tabs.types, tabs.abilities, tabs.docs, tabs.tests ]
+
+            TypesTab ->
+                tabOrCard [ tabs.terms ] tabs.types [ tabs.abilities, tabs.docs, tabs.tests ]
+
+            AbilitiesTab ->
+                tabOrCard [ tabs.terms, tabs.types ] tabs.abilities [ tabs.docs, tabs.tests ]
+
+            DocsTab ->
+                tabOrCard [ tabs.terms, tabs.types, tabs.abilities ] tabs.docs [ tabs.tests ]
+
+            TestsTab ->
+                tabOrCard [ tabs.terms, tabs.types, tabs.abilities, tabs.docs ] tabs.tests []
+
+
+activeTab : GroupedDependents -> DependentsItemTab -> Maybe DependentsItemTab
+activeTab { terms, types, tests, abilities, docs } tab =
+    let
+        tabWithItems t items =
+            if List.isEmpty items then
+                Nothing
+
+            else
+                Just t
+
+        tabs_ =
+            [ tabWithItems TermsTab terms
+            , tabWithItems TypesTab types
+            , tabWithItems AbilitiesTab abilities
+            , tabWithItems DocsTab docs
+            , tabWithItems TestsTab tests
+            ]
+                |> MaybeE.values
+    in
+    if List.member tab tabs_ then
+        Just tab
+
+    else
+        List.head tabs_
+
+
+dependentsByQuery : String -> List DefinitionMatch -> List DefinitionMatch
+dependentsByQuery query deps =
+    List.filter
+        (DefinitionMatch.fqn
+            >> FQN.toString
+            >> String.toLower
+            >> String.contains query
+        )
+        deps
+
+
+viewSearchResults : ViewConfig msg -> Html msg
+viewSearchResults cfg =
+    let
+        { terms, types, tests, abilities, docs } =
+            cfg.dependents
+                |> dependentsByQuery cfg.state.searchQuery
+                |> groupDependents
+
+        results =
+            [ blankIfEmpty (viewDependents "term-reference" cfg.openDefinition terms) terms
+            , blankIfEmpty (viewDependents "type-reference" cfg.openDefinition types) types
+            , blankIfEmpty (viewDependents "type-reference" cfg.openDefinition abilities) abilities
+            , blankIfEmpty (viewDependents "term-reference" cfg.openDefinition docs) docs
+            , blankIfEmpty (viewDependents "term-reference" cfg.openDefinition tests) tests
+            ]
+    in
+    div [ class "search-results" ] results
+
+
+isSearching : ViewConfig msg -> Bool
+isSearching cfg =
+    not (String.isEmpty cfg.state.searchQuery)
+
+
+view : ViewConfig msg -> WorkspaceCard msg
+view cfg =
+    let
+        lib =
+            cfg.item
+                |> DefinitionItem.toLib
+                |> Maybe.map WorkspaceCard.viewLibraryTag
+                |> Maybe.withDefault UI.nothing
+
+        ({ terms, types, tests, abilities, docs } as group) =
+            groupDependents cfg.dependents
+
+        itemContent =
+            let
+                content =
+                    if isSearching cfg then
+                        viewSearchResults cfg
+
+                    else
+                        case activeTab group cfg.state.activeTab of
+                            Just TermsTab ->
+                                viewDependents "term-reference" cfg.openDefinition terms
+
+                            Just TypesTab ->
+                                viewDependents "type-reference" cfg.openDefinition types
+
+                            Just AbilitiesTab ->
+                                viewDependents "type-reference" cfg.openDefinition abilities
+
+                            Just DocsTab ->
+                                viewDependents "term-reference" cfg.openDefinition docs
+
+                            Just TestsTab ->
+                                viewDependents "term-reference" cfg.openDefinition tests
+
+                            Nothing ->
+                                div [ class "empty-state" ]
+                                    [ FQN.view (DefinitionItem.name cfg.item)
+                                    , text "has no direct dependents."
+                                    ]
+            in
+            div [ class "workspace-dependents-item-card_content" ]
+                [ content
+                ]
+
+        numDeps =
+            List.length cfg.dependents
+
+        dependentsOfDefinition =
+            Click.onClick (cfg.openDefinition cfg.dependentsOfRef)
+                |> Click.view [] [ FQN.view (DefinitionItem.name cfg.item) ]
+
+        search =
+            div [ class "search-dependents" ]
+                [ TextField.fieldWithoutLabel cfg.updateQuery "Search dependents" cfg.state.searchQuery
+                    |> TextField.withIcon Icon.search
+                    |> TextField.view
+                ]
+
+        withSearch card =
+            if List.length cfg.dependents > 5 then
+                WorkspaceCard.withSubtitleBar search card
+
+            else
+                card
+    in
+    WorkspaceCard.empty
+        |> WorkspaceCard.withTitlebarLeft
+            [ lib
+            , dependentsOfDefinition
+            , strong [ class "subdued" ]
+                [ text
+                    (String.fromInt numDeps
+                        ++ " "
+                        ++ pluralize "direct dependent"
+                            "direct dependents"
+                            numDeps
+                    )
+                ]
+            ]
+        |> WorkspaceCard.withClose cfg.closeItem
+        |> withTabList cfg group
+        |> withSearch
+        |> WorkspaceCard.withContent
+            [ itemContent
+            ]

--- a/src/Code2/Workspace/WorkspaceItem.elm
+++ b/src/Code2/Workspace/WorkspaceItem.elm
@@ -1,0 +1,104 @@
+module Code2.Workspace.WorkspaceItem exposing (..)
+
+import Code.Definition.AbilityConstructor exposing (AbilityConstructor(..))
+import Code.Definition.DataConstructor exposing (DataConstructor(..))
+import Code.Definition.Info as Info
+import Code.Definition.Reference as Reference exposing (Reference)
+import Code.Definition.Term exposing (Term(..))
+import Code.Definition.Type exposing (Type(..))
+import Code.FullyQualifiedName exposing (FQN)
+import Code2.Workspace.DefinitionItem exposing (DefinitionItem(..))
+import Code2.Workspace.DefinitionMatch exposing (DefinitionMatch)
+import Code2.Workspace.DefinitionWorkspaceItemState exposing (DefinitionWorkspaceItemState)
+import Code2.Workspace.DependentsWorkspaceItemState exposing (DependentsWorkspaceItemState)
+import Code2.Workspace.WorkspaceItemRef exposing (SearchResultsRef, WorkspaceItemRef(..))
+import Http
+import Maybe.Extra as MaybeE
+
+
+type alias SearchResultsItem =
+    { ref : SearchResultsRef }
+
+
+type LoadedWorkspaceItem
+    = DefinitionWorkspaceItem Reference DefinitionWorkspaceItemState DefinitionItem
+    | SearchResultsWorkspaceItem SearchResultsItem
+    | DependentsWorkspaceItem Reference DependentsWorkspaceItemState DefinitionItem (List DefinitionMatch)
+
+
+type WorkspaceItem
+    = Loading WorkspaceItemRef
+    | Failure WorkspaceItemRef Http.Error
+    | Success WorkspaceItemRef LoadedWorkspaceItem
+
+
+reference : WorkspaceItem -> WorkspaceItemRef
+reference item =
+    case item of
+        Loading ref ->
+            ref
+
+        Failure ref _ ->
+            ref
+
+        Success ref _ ->
+            ref
+
+
+definitionReference : WorkspaceItem -> Maybe Reference
+definitionReference item =
+    let
+        iRef =
+            reference item
+    in
+    case iRef of
+        SearchResultsItemRef _ ->
+            Nothing
+
+        DefinitionItemRef ref ->
+            Just ref
+
+        DependentsItemRef ref ->
+            Just ref
+
+
+allFqns : WorkspaceItem -> List FQN
+allFqns item =
+    let
+        fromRef =
+            MaybeE.values
+                [ item
+                    |> definitionReference
+                    |> Maybe.andThen Reference.fqn
+                ]
+    in
+    case item of
+        Success _ loadedItem ->
+            case loadedItem of
+                DefinitionWorkspaceItem _ _ (TermItem (Term _ _ { info })) ->
+                    Info.allFqns info
+
+                DefinitionWorkspaceItem _ _ (TypeItem (Type _ _ { info })) ->
+                    Info.allFqns info
+
+                DefinitionWorkspaceItem _ _ (AbilityConstructorItem (AbilityConstructor _ { info })) ->
+                    Info.allFqns info
+
+                DefinitionWorkspaceItem _ _ (DataConstructorItem (DataConstructor _ { info })) ->
+                    Info.allFqns info
+
+                _ ->
+                    fromRef
+
+        _ ->
+            fromRef
+
+
+isSameRef : WorkspaceItem -> WorkspaceItemRef -> Bool
+isSameRef item ref =
+    reference item == ref
+
+
+isSameByRef : WorkspaceItem -> WorkspaceItem -> Bool
+isSameByRef a b =
+    reference a == reference b

--- a/src/Code2/Workspace/WorkspaceItemRef.elm
+++ b/src/Code2/Workspace/WorkspaceItemRef.elm
@@ -1,0 +1,88 @@
+module Code2.Workspace.WorkspaceItemRef exposing (..)
+
+import Code.Definition.Reference as Reference exposing (Reference)
+import Code.FullyQualifiedName as FQN
+import Code.Hash as Hash
+import Maybe.Extra as MaybeE
+
+
+type SearchResultsRef
+    = SearchResultsRef String
+
+
+type WorkspaceItemRef
+    = DefinitionItemRef Reference
+    | SearchResultsItemRef SearchResultsRef
+    | DependentsItemRef Reference
+
+
+definitionReference : WorkspaceItemRef -> Maybe Reference
+definitionReference ref =
+    case ref of
+        DefinitionItemRef r ->
+            Just r
+
+        DependentsItemRef r ->
+            Just r
+
+        _ ->
+            Nothing
+
+
+toString : WorkspaceItemRef -> String
+toString ref =
+    case ref of
+        DefinitionItemRef r ->
+            "Definition: " ++ Reference.toString r
+
+        SearchResultsItemRef (SearchResultsRef r) ->
+            "Search results:" ++ r
+
+        DependentsItemRef r ->
+            "Dependents of :" ++ Reference.toString r
+
+
+toDomString : WorkspaceItemRef -> String
+toDomString ref =
+    ref |> toString |> String.replace "." "__"
+
+
+toHumanString : WorkspaceItemRef -> String
+toHumanString ref =
+    let
+        defRefToString r =
+            let
+                fqn =
+                    Reference.fqn r
+
+                hash =
+                    Reference.hash r
+            in
+            fqn
+                |> Maybe.map FQN.toString
+                |> MaybeE.or (Maybe.map Hash.toShortString hash)
+                |> Maybe.withDefault (Reference.toHumanString r)
+    in
+    case ref of
+        DefinitionItemRef r ->
+            defRefToString r
+
+        SearchResultsItemRef (SearchResultsRef r) ->
+            r
+
+        DependentsItemRef r ->
+            defRefToString r
+
+
+toUrlPath : WorkspaceItemRef -> List String
+toUrlPath wsRef =
+    case wsRef of
+        DefinitionItemRef r ->
+            Reference.toUrlPath r
+
+        DependentsItemRef r ->
+            "dependents-of" :: Reference.toUrlPath r
+
+        _ ->
+            -- TODO
+            [ "search" ]

--- a/src/Code2/Workspace/WorkspaceItems.elm
+++ b/src/Code2/Workspace/WorkspaceItems.elm
@@ -1,0 +1,565 @@
+{-
+   WorkspaceItems is the main data structure for working with definitions in
+   a WorkspacePane. It supports holding Loading definitions and inserting
+   definitions after another.
+
+   It features a `focus` indicator and a before and after just like a Zipper.
+   `focus` can be changed with `next` and `prev`.
+
+   TODO: we don't care about this invariant any more, now that we have split panes?
+   Invariants:
+     It structurally can't hold the invariant that it should not contain
+     duplicates, so this is instead enforced via the API; uniqueness is
+     determined by Reference and Hash.
+-}
+-- TODO: All reference equality check should reach into definition for hash
+-- equality when possible
+
+
+module Code2.Workspace.WorkspaceItems exposing (..)
+
+import Code.Definition.Reference exposing (Reference)
+import Code.FullyQualifiedName exposing (FQN)
+import Code2.Workspace.DefinitionWorkspaceItemState exposing (DefinitionWorkspaceItemState)
+import Code2.Workspace.DependentsWorkspaceItemState exposing (DependentsWorkspaceItemState)
+import Code2.Workspace.WorkspaceItem as WorkspaceItem exposing (WorkspaceItem)
+import Code2.Workspace.WorkspaceItemRef exposing (WorkspaceItemRef)
+import List
+import List.Extra as ListE
+import Maybe.Extra as MaybeE
+
+
+{-| This technically allows multiple of the same definition across the 3 fields.
+This is conceptionally not allowed and is enforced by the helper functions.
+-}
+type WorkspaceItems
+    = Empty
+    | WorkspaceItems
+        { before : List WorkspaceItem
+        , focus : WorkspaceItem
+        , after : List WorkspaceItem
+        }
+
+
+init : Maybe WorkspaceItem -> WorkspaceItems
+init focused =
+    case focused of
+        Nothing ->
+            Empty
+
+        Just i ->
+            singleton i
+
+
+fromItems :
+    List WorkspaceItem
+    -> WorkspaceItem
+    -> List WorkspaceItem
+    -> WorkspaceItems
+fromItems before focus_ after =
+    WorkspaceItems { before = before, focus = focus_, after = after }
+
+
+empty : WorkspaceItems
+empty =
+    Empty
+
+
+isEmpty : WorkspaceItems -> Bool
+isEmpty workspaceItems =
+    case workspaceItems of
+        Empty ->
+            True
+
+        WorkspaceItems _ ->
+            False
+
+
+length : WorkspaceItems -> Int
+length items =
+    items
+        |> toList
+        |> List.length
+
+
+singleton : WorkspaceItem -> WorkspaceItems
+singleton item =
+    WorkspaceItems { before = [], focus = item, after = [] }
+
+
+
+-- MODIFY
+
+
+appendWithFocus : WorkspaceItems -> WorkspaceItem -> WorkspaceItems
+appendWithFocus items item =
+    WorkspaceItems { before = toList items, focus = item, after = [] }
+
+
+prependWithFocus : WorkspaceItems -> WorkspaceItem -> WorkspaceItems
+prependWithFocus workspaceItems item =
+    case workspaceItems of
+        Empty ->
+            singleton item
+
+        WorkspaceItems items ->
+            WorkspaceItems
+                { before = []
+                , focus = item
+                , after =
+                    items.before ++ (items.focus :: items.after)
+                }
+
+
+{-| Insert before a Hash. If the Hash is not in WorkspaceItems, insert with
+focus. If the element to insert already exists in WorkspaceItems, move it to
+after the provided Hash
+-}
+insertWithFocusBefore :
+    WorkspaceItems
+    -> WorkspaceItemRef
+    -> WorkspaceItem
+    -> WorkspaceItems
+insertWithFocusBefore items beforeRef toInsert =
+    case items of
+        Empty ->
+            singleton toInsert
+
+        WorkspaceItems _ ->
+            if includesItem items beforeRef then
+                let
+                    insertBefore item =
+                        if WorkspaceItem.isSameRef item beforeRef then
+                            [ toInsert, item ]
+
+                        else
+                            [ item ]
+
+                    make ( before, afterInclusive ) =
+                        WorkspaceItems
+                            { before = before
+                            , focus = toInsert
+                            , after = List.drop 1 afterInclusive
+                            }
+                in
+                items
+                    |> toList
+                    |> List.concatMap insertBefore
+                    |> ListE.splitWhen (WorkspaceItem.isSameByRef toInsert)
+                    |> Maybe.map make
+                    |> Maybe.withDefault (singleton toInsert)
+
+            else
+                prependWithFocus items toInsert
+
+
+{-| Insert after a Hash. If the Hash is not in WorkspaceItems, insert at the
+end. If the element to insert already exists in WorkspaceItems, move it to
+after the provided Hash
+-}
+insertWithFocusAfter :
+    WorkspaceItems
+    -> WorkspaceItemRef
+    -> WorkspaceItem
+    -> WorkspaceItems
+insertWithFocusAfter items afterRef toInsert =
+    case items of
+        Empty ->
+            singleton toInsert
+
+        WorkspaceItems _ ->
+            if includesItem items afterRef then
+                let
+                    insertAfter item =
+                        if WorkspaceItem.isSameRef item afterRef then
+                            [ item, toInsert ]
+
+                        else
+                            [ item ]
+
+                    make ( before, afterInclusive ) =
+                        WorkspaceItems
+                            { before = before
+                            , focus = toInsert
+                            , after = List.drop 1 afterInclusive
+                            }
+                in
+                items
+                    |> toList
+                    |> List.concatMap insertAfter
+                    |> ListE.splitWhen (WorkspaceItem.isSameByRef toInsert)
+                    |> Maybe.map make
+                    |> Maybe.withDefault (singleton toInsert)
+
+            else
+                appendWithFocus items toInsert
+
+
+replace : WorkspaceItems -> WorkspaceItemRef -> WorkspaceItem -> WorkspaceItems
+replace items ref newItem =
+    let
+        replaceMatching i =
+            if WorkspaceItem.isSameRef i ref then
+                newItem
+
+            else
+                i
+    in
+    map replaceMatching items
+
+
+remove : WorkspaceItems -> WorkspaceItemRef -> WorkspaceItems
+remove items ref =
+    case items of
+        Empty ->
+            Empty
+
+        WorkspaceItems data ->
+            let
+                without r =
+                    ListE.filterNot (\i -> WorkspaceItem.isSameRef i r)
+            in
+            if WorkspaceItem.isSameRef data.focus ref then
+                let
+                    rightBeforeFocus =
+                        ListE.last data.before
+
+                    rightAfterFocus =
+                        List.head data.after
+                in
+                case rightAfterFocus of
+                    Just i ->
+                        WorkspaceItems
+                            { before = data.before
+                            , focus = i
+                            , after = without (WorkspaceItem.reference i) data.after
+                            }
+
+                    Nothing ->
+                        case rightBeforeFocus of
+                            Just i ->
+                                WorkspaceItems
+                                    { before = without (WorkspaceItem.reference i) data.before
+                                    , focus = i
+                                    , after = data.after
+                                    }
+
+                            Nothing ->
+                                Empty
+
+            else
+                WorkspaceItems
+                    { before = without ref data.before
+                    , focus = data.focus
+                    , after = without ref data.after
+                    }
+
+
+
+-- QUERY
+
+
+includesItem : WorkspaceItems -> WorkspaceItemRef -> Bool
+includesItem items ref =
+    items |> references |> List.member ref
+
+
+references : WorkspaceItems -> List WorkspaceItemRef
+references items =
+    items
+        |> toList
+        |> List.map WorkspaceItem.reference
+
+
+definitionReferences : WorkspaceItems -> List Reference
+definitionReferences items =
+    items
+        |> toList
+        |> List.map WorkspaceItem.definitionReference
+        |> MaybeE.values
+
+
+fqns : WorkspaceItems -> List FQN
+fqns items =
+    items
+        |> toList
+        |> List.concatMap WorkspaceItem.allFqns
+
+
+head : WorkspaceItems -> Maybe WorkspaceItem
+head items =
+    items
+        |> toList
+        |> List.head
+
+
+last : WorkspaceItems -> Maybe WorkspaceItem
+last items =
+    items
+        |> toList
+        |> ListE.last
+
+
+
+-- Focus
+
+
+focus : WorkspaceItems -> Maybe WorkspaceItem
+focus items =
+    case items of
+        Empty ->
+            Nothing
+
+        WorkspaceItems data ->
+            Just data.focus
+
+
+focusedReference : WorkspaceItems -> Maybe WorkspaceItemRef
+focusedReference items =
+    items
+        |> focus
+        |> Maybe.map WorkspaceItem.reference
+
+
+focusOn : WorkspaceItems -> WorkspaceItemRef -> WorkspaceItems
+focusOn items ref =
+    let
+        fromSplits ( before, afterInclusive ) =
+            case afterInclusive of
+                [] ->
+                    Nothing
+
+                newFocus :: after ->
+                    Just
+                        { before = before
+                        , focus = newFocus
+                        , after = after
+                        }
+    in
+    items
+        |> toList
+        |> ListE.splitWhen (\i -> WorkspaceItem.isSameRef i ref)
+        |> Maybe.andThen fromSplits
+        |> Maybe.map WorkspaceItems
+        |> Maybe.withDefault items
+
+
+isFocused : WorkspaceItems -> WorkspaceItemRef -> Bool
+isFocused workspaceItems ref =
+    workspaceItems
+        |> focus
+        |> Maybe.map (\i -> WorkspaceItem.isSameRef i ref)
+        |> Maybe.withDefault False
+
+
+focusIndex : WorkspaceItems -> Maybe Int
+focusIndex workspaceItems =
+    case workspaceItems of
+        Empty ->
+            Nothing
+
+        WorkspaceItems items ->
+            items.before
+                |> List.length
+                |> Maybe.Just
+
+
+{-| Moves the focused item up before the previous item, keeps focus |
+-}
+moveUp : WorkspaceItems -> WorkspaceItems
+moveUp items =
+    case items of
+        Empty ->
+            Empty
+
+        WorkspaceItems data ->
+            case ListE.unconsLast data.before of
+                Nothing ->
+                    items
+
+                Just ( i, before ) ->
+                    WorkspaceItems
+                        { before = before
+                        , focus = data.focus
+                        , after = i :: data.after
+                        }
+
+
+{-| Moves the focused item down before the next item, keeps focus |
+-}
+moveDown : WorkspaceItems -> WorkspaceItems
+moveDown items =
+    case items of
+        Empty ->
+            Empty
+
+        WorkspaceItems data ->
+            case data.after of
+                [] ->
+                    items
+
+                i :: after ->
+                    WorkspaceItems
+                        { before = data.before ++ [ i ]
+                        , focus = data.focus
+                        , after = after
+                        }
+
+
+next : WorkspaceItems -> WorkspaceItems
+next items =
+    case items of
+        Empty ->
+            Empty
+
+        WorkspaceItems data ->
+            case data.after of
+                [] ->
+                    items
+
+                newFocus :: rest ->
+                    WorkspaceItems
+                        { before = data.before ++ [ data.focus ]
+                        , focus = newFocus
+                        , after = rest
+                        }
+
+
+prev : WorkspaceItems -> WorkspaceItems
+prev items =
+    case items of
+        Empty ->
+            Empty
+
+        WorkspaceItems data ->
+            case ListE.unconsLast data.before of
+                Nothing ->
+                    items
+
+                Just ( newFocus, newBefore ) ->
+                    WorkspaceItems
+                        { before = newBefore
+                        , focus = newFocus
+                        , after = data.focus :: data.after
+                        }
+
+
+
+-- TRANFORM
+
+
+updateDefinitionItemState :
+    (DefinitionWorkspaceItemState -> DefinitionWorkspaceItemState)
+    -> WorkspaceItemRef
+    -> WorkspaceItems
+    -> WorkspaceItems
+updateDefinitionItemState f ref wItems =
+    let
+        update_ workspaceItem =
+            case workspaceItem of
+                WorkspaceItem.Success r (WorkspaceItem.DefinitionWorkspaceItem defRef state innerItem) ->
+                    if ref == r then
+                        WorkspaceItem.Success
+                            r
+                            (WorkspaceItem.DefinitionWorkspaceItem defRef (f state) innerItem)
+
+                    else
+                        workspaceItem
+
+                _ ->
+                    workspaceItem
+    in
+    map update_ wItems
+
+
+updateDependentsItemState :
+    (DependentsWorkspaceItemState -> DependentsWorkspaceItemState)
+    -> WorkspaceItemRef
+    -> WorkspaceItems
+    -> WorkspaceItems
+updateDependentsItemState f ref wItems =
+    let
+        update_ workspaceItem =
+            case workspaceItem of
+                WorkspaceItem.Success r (WorkspaceItem.DependentsWorkspaceItem dependentsOfRef state defItem dependents) ->
+                    if ref == r then
+                        WorkspaceItem.Success
+                            r
+                            (WorkspaceItem.DependentsWorkspaceItem dependentsOfRef (f state) defItem dependents)
+
+                    else
+                        workspaceItem
+
+                _ ->
+                    workspaceItem
+    in
+    map update_ wItems
+
+
+map :
+    (WorkspaceItem -> WorkspaceItem)
+    -> WorkspaceItems
+    -> WorkspaceItems
+map f wItems =
+    case wItems of
+        Empty ->
+            Empty
+
+        WorkspaceItems data ->
+            WorkspaceItems
+                { before = List.map f data.before
+                , focus = f data.focus
+                , after = List.map f data.after
+                }
+
+
+find : (WorkspaceItem -> Bool) -> WorkspaceItems -> Maybe WorkspaceItem
+find pred wItems =
+    wItems
+        |> toList
+        |> ListE.find pred
+
+
+all : (WorkspaceItem -> Bool) -> WorkspaceItems -> Bool
+all pred wItems =
+    wItems
+        |> toList
+        |> List.all pred
+
+
+any : (WorkspaceItem -> Bool) -> WorkspaceItems -> Bool
+any pred wItems =
+    wItems
+        |> toList
+        |> List.any pred
+
+
+mapToList : (WorkspaceItem -> Bool -> a) -> WorkspaceItems -> List a
+mapToList f wItems =
+    case wItems of
+        Empty ->
+            []
+
+        WorkspaceItems data ->
+            let
+                before =
+                    data.before
+                        |> List.map (\i -> f i False)
+
+                after =
+                    data.after
+                        |> List.map (\i -> f i False)
+            in
+            before ++ (f data.focus True :: after)
+
+
+{-| Converting the workspace items to a list, looses the focus indicator
+-}
+toList : WorkspaceItems -> List WorkspaceItem
+toList wItems =
+    case wItems of
+        Empty ->
+            []
+
+        WorkspaceItems items ->
+            items.before ++ (items.focus :: items.after)

--- a/src/Code2/Workspace/WorkspaceMinimap.elm
+++ b/src/Code2/Workspace/WorkspaceMinimap.elm
@@ -1,0 +1,177 @@
+module Code2.Workspace.WorkspaceMinimap exposing (Minimap, view)
+
+import Code.Definition.AbilityConstructor exposing (AbilityConstructor(..))
+import Code.Definition.Category as Category exposing (Category)
+import Code.Definition.DataConstructor exposing (DataConstructor(..))
+import Code.Definition.Term exposing (Term(..))
+import Code.Definition.Type as Type exposing (Type(..))
+import Code.FullyQualifiedName as FQN
+import Code2.Workspace.DefinitionItem as DefinitionItem exposing (DefinitionItem(..))
+import Code2.Workspace.WorkspaceItem as WorkspaceItem exposing (LoadedWorkspaceItem(..), WorkspaceItem(..))
+import Code2.Workspace.WorkspaceItemRef exposing (WorkspaceItemRef)
+import Code2.Workspace.WorkspaceItems as WorkspaceItems exposing (WorkspaceItems, focus, mapToList)
+import Html exposing (Html, div, header, text)
+import Html.Attributes exposing (class, classList, hidden)
+import Html.Events exposing (onClick)
+import UI
+import UI.Button as Button
+import UI.Click as Click
+import UI.Icon as Icon
+import UI.KeyboardShortcut as KeyboardShortcut exposing (KeyboardShortcut(..))
+import UI.KeyboardShortcut.Key as Key
+import UI.Placeholder as Placeholder
+import UI.StatusBanner as StatusBanner
+
+
+type alias Minimap msg =
+    { keyboardShortcut : KeyboardShortcut.Model
+    , workspaceItems : WorkspaceItems
+    , selectItemMsg : WorkspaceItemRef -> msg
+    , closeAllMsg : msg
+    , closeItemMsg : WorkspaceItemRef -> msg
+    , isToggled : Bool
+    , toggleMinimapMsg : msg
+    }
+
+
+view : Minimap msg -> Html msg
+view model =
+    div
+        [ classList [ ( "workspace-minimap", True ), ( "workspace-minimap_toggled", model.isToggled ) ] ]
+        [ viewExpanded model
+        , viewCollapsed model
+        ]
+
+
+viewCollapsed : Minimap msg -> Html msg
+viewCollapsed model =
+    let
+        viewContent : WorkspaceItem -> List (Html msg)
+        viewContent item =
+            let
+                focusIndex =
+                    model.workspaceItems
+                        |> WorkspaceItems.focusIndex
+                        |> Maybe.withDefault 0
+            in
+            [ Button.icon model.toggleMinimapMsg Icon.unfoldedMap
+                |> Button.small
+                |> Button.view
+            , viewItem model focusIndex ( item, True )
+            ]
+
+        content =
+            model.workspaceItems
+                |> focus
+                |> Maybe.map viewContent
+                |> Maybe.withDefault []
+    in
+    div [ class "workspace-minimap_collapsed" ] content
+
+
+viewExpanded : Minimap msg -> Html msg
+viewExpanded model =
+    let
+        header =
+            viewHeader model.toggleMinimapMsg model.closeAllMsg
+
+        entries =
+            model.workspaceItems
+                |> mapToList Tuple.pair
+                |> List.indexedMap (viewItem model)
+                |> div [ class "workspace-minimap_entries" ]
+    in
+    div
+        [ class "workspace-minimap_expanded" ]
+        [ header, entries ]
+
+
+viewHeader : msg -> msg -> Html msg
+viewHeader toggleMinimapMsg closeAllMsg =
+    header
+        [ class "workspace-minimap_header" ]
+        [ Click.view
+            [ class "workspace-minimap_header_title" ]
+            [ Icon.view Icon.caretDown, text "MAP" ]
+            (Click.onClick toggleMinimapMsg)
+        , Click.view
+            [ class "workspace-minimap_close" ]
+            [ text "Close all" ]
+            (Click.onClick closeAllMsg)
+        ]
+
+
+viewItem : Minimap msg -> Int -> ( WorkspaceItem, Bool ) -> Html msg
+viewItem { selectItemMsg, closeItemMsg, keyboardShortcut } index ( item, focused ) =
+    let
+        wsRef =
+            WorkspaceItem.reference item
+
+        content =
+            case item of
+                Loading _ ->
+                    div
+                        [ class "workspace-minimap_item_content" ]
+                        [ Placeholder.text
+                            |> Placeholder.view
+                        ]
+
+                Failure _ _ ->
+                    div
+                        [ class "workspace-minimap_item_content" ]
+                        [ StatusBanner.bad "Couldn't fetch item" ]
+
+                Success _ (DefinitionWorkspaceItem _ _ defItem) ->
+                    let
+                        ( info, category ) =
+                            case defItem of
+                                TermItem (Term _ category_ detail) ->
+                                    ( detail.info, Category.Term category_ )
+
+                                TypeItem (Type _ category_ detail) ->
+                                    ( detail.info, Category.Type category_ )
+
+                                DataConstructorItem (DataConstructor _ detail) ->
+                                    ( detail.info, Category.Type Type.DataType )
+
+                                AbilityConstructorItem (AbilityConstructor _ detail) ->
+                                    ( detail.info, Category.Type Type.AbilityType )
+                    in
+                    viewItemContent category info.name
+
+                Success _ (DependentsWorkspaceItem _ _ defItem _) ->
+                    div
+                        [ class "workspace-minimap_item_content" ]
+                        [ Icon.view Icon.dependents
+                        , text "Dependents of "
+                        , FQN.view (DefinitionItem.name defItem)
+                        ]
+
+                _ ->
+                    UI.nothing
+    in
+    div
+        [ classList [ ( "workspace-minimap_item", True ), ( "focused", focused ) ]
+        , onClick (selectItemMsg wsRef)
+        ]
+        [ content
+        , Button.icon (closeItemMsg wsRef) Icon.x |> Button.small |> Button.stopPropagation |> Button.subdued |> Button.view
+        , div
+            [ hidden True ]
+            -- currently hidden as feature is not supported yet
+            [ viewItemKeyboardShortcut keyboardShortcut index ]
+        ]
+
+
+viewItemContent : Category -> FQN.FQN -> Html msg
+viewItemContent category name =
+    div
+        [ class "workspace-minimap_item_content" ]
+        [ Icon.view (Category.icon category)
+        , FQN.view name
+        ]
+
+
+viewItemKeyboardShortcut : KeyboardShortcut.Model -> Int -> Html msg
+viewItemKeyboardShortcut model index =
+    KeyboardShortcut.view model (Chord (Key.fromString "J") (Key.fromString (String.fromInt index)))

--- a/src/Code2/Workspace/WorkspacePane.elm
+++ b/src/Code2/Workspace/WorkspacePane.elm
@@ -1,0 +1,867 @@
+module Code2.Workspace.WorkspacePane exposing (..)
+
+import Code.CodebaseApi as CodebaseApi
+import Code.Config exposing (Config)
+import Code.Definition.Doc as Doc
+import Code.Definition.Reference exposing (Reference)
+import Code.DefinitionSummaryTooltip as DefinitionSummaryTooltip
+import Code.FullyQualifiedName exposing (FQN)
+import Code.Syntax.SyntaxConfig as SyntaxConfig
+import Code2.Workspace.DefinitionItem as DefinitionItem exposing (DefinitionItem)
+import Code2.Workspace.DefinitionMatch as DefinitionMatch exposing (DefinitionMatch)
+import Code2.Workspace.DefinitionWorkspaceItemState as DefinitionWorkspaceItemState exposing (DefinitionItemTab)
+import Code2.Workspace.DependentsWorkspaceItemState as DependentsWorkspaceItemState exposing (DependentsItemTab)
+import Code2.Workspace.WorkspaceCard as WorkspaceCard
+import Code2.Workspace.WorkspaceDefinitionItemCard as WorkspaceDefinitionItemCard
+import Code2.Workspace.WorkspaceDependentsItemCard as WorkspaceDependentsItemCard
+import Code2.Workspace.WorkspaceItem as WorkspaceItem exposing (WorkspaceItem)
+import Code2.Workspace.WorkspaceItemRef as WorkspaceItemRef exposing (WorkspaceItemRef(..))
+import Code2.Workspace.WorkspaceItems as WorkspaceItems exposing (WorkspaceItems)
+import Code2.Workspace.WorkspaceMinimap as WorkspaceMinimap
+import Html exposing (Html, div, p, pre, strong, text)
+import Html.Attributes exposing (class, classList, id)
+import Html.Events exposing (onClick)
+import Json.Decode as Decode
+import Lib.HttpApi as HttpApi exposing (ApiRequest, HttpResult)
+import Lib.OperatingSystem exposing (OperatingSystem)
+import Lib.ScrollTo as ScrollTo
+import Lib.Util as Util
+import Maybe.Extra as MaybeE
+import Set exposing (Set)
+import Set.Extra as SetE
+import Task
+import UI
+import UI.Button as Button
+import UI.Click as Click
+import UI.Icon as Icon
+import UI.KeyboardShortcut as KeyboardShortcut exposing (KeyboardShortcut(..))
+import UI.KeyboardShortcut.Key exposing (Key(..))
+import UI.KeyboardShortcut.KeyboardEvent as KeyboardEvent
+import UI.Placeholder as Placeholder
+import UI.StatusIndicator as StatusIndicator
+
+
+
+-- MODEL
+
+
+type alias Model =
+    { workspaceItems : WorkspaceItems
+    , definitionSummaryTooltip : DefinitionSummaryTooltip.Model
+    , collapsedItems : Set String -- Serialized WorkspaceItemRef
+    , keyboardShortcut : KeyboardShortcut.Model
+    , isMinimapToggled : Bool
+    }
+
+
+init : OperatingSystem -> ( Model, Cmd Msg )
+init os =
+    ( { workspaceItems = WorkspaceItems.init Nothing
+      , definitionSummaryTooltip = DefinitionSummaryTooltip.init
+      , collapsedItems = Set.empty
+      , keyboardShortcut = KeyboardShortcut.init os
+      , isMinimapToggled = False
+      }
+    , Cmd.none
+    )
+
+
+
+-- UPDATE
+
+
+type Msg
+    = NoOp
+    | PaneFocus
+    | FetchDefinitionItemFinished Reference (HttpResult DefinitionItem)
+    | Refetch WorkspaceItemRef
+    | CloseAll
+    | CloseWorkspaceItem WorkspaceItemRef
+    | ToggleMinimap
+    | ChangeDefinitionItemTab WorkspaceItemRef DefinitionItemTab
+    | ToggleCodeFold WorkspaceItemRef
+    | ChangeDependentsItemTab WorkspaceItemRef DependentsItemTab
+    | OpenDefinition Reference
+    | ShowDependentsOf WorkspaceItemRef
+    | UpdateDependentsSearchQuery WorkspaceItemRef String
+    | FindWithinNamespace WorkspaceItemRef FQN
+    | ChangePerspective WorkspaceItemRef Reference FQN
+    | FetchDependentsFinished WorkspaceItemRef Reference (HttpResult ( DefinitionItem, List DefinitionMatch ))
+    | ToggleDocFold WorkspaceItemRef Doc.FoldId
+    | ToggleNamespaceDropdown WorkspaceItemRef
+    | ToggleFold WorkspaceItemRef
+    | Keydown KeyboardEvent.KeyboardEvent
+    | SetFocusedItem WorkspaceItemRef
+    | DefinitionSummaryTooltipMsg DefinitionSummaryTooltip.Msg
+    | KeyboardShortcutMsg KeyboardShortcut.Msg
+
+
+type OutMsg
+    = NoOut
+    | RequestPaneFocus
+    | FocusOn WorkspaceItemRef
+    | RequestFindInNamespace FQN
+    | RequestChangePerspective Reference FQN
+    | Emptied
+
+
+update : Config -> String -> Msg -> Model -> ( Model, Cmd Msg, OutMsg )
+update config paneId msg model =
+    case msg of
+        PaneFocus ->
+            ( model, Cmd.none, RequestPaneFocus )
+
+        Refetch ref ->
+            let
+                ( model_, cmd ) =
+                    case ref of
+                        SearchResultsItemRef _ ->
+                            ( model, Cmd.none )
+
+                        DefinitionItemRef dRef ->
+                            let
+                                nextWorkspaceItems =
+                                    WorkspaceItems.replace model.workspaceItems ref (WorkspaceItem.Loading ref)
+                            in
+                            ( { model | workspaceItems = nextWorkspaceItems }
+                            , HttpApi.perform config.api (fetchDefinition config dRef)
+                            )
+
+                        DependentsItemRef _ ->
+                            ( model, Cmd.none )
+            in
+            ( model_, cmd, NoOut )
+
+        FetchDefinitionItemFinished dRef (Ok defItem) ->
+            let
+                workspaceItemRef =
+                    WorkspaceItemRef.DefinitionItemRef dRef
+
+                activeTab =
+                    if DefinitionItem.isDoc defItem then
+                        DefinitionWorkspaceItemState.DocsTab
+
+                    else
+                        DefinitionWorkspaceItemState.CodeTab
+
+                workspaceItems =
+                    WorkspaceItems.replace
+                        model.workspaceItems
+                        workspaceItemRef
+                        (WorkspaceItem.Success workspaceItemRef
+                            (WorkspaceItem.DefinitionWorkspaceItem
+                                dRef
+                                (DefinitionWorkspaceItemState.init activeTab)
+                                defItem
+                            )
+                        )
+            in
+            ( { model | workspaceItems = workspaceItems }, Cmd.none, NoOut )
+
+        FetchDefinitionItemFinished dRef (Err e) ->
+            let
+                workspaceItemRef =
+                    WorkspaceItemRef.DefinitionItemRef dRef
+            in
+            ( { model
+                | workspaceItems =
+                    WorkspaceItems.replace
+                        model.workspaceItems
+                        workspaceItemRef
+                        (WorkspaceItem.Failure workspaceItemRef e)
+              }
+            , Cmd.none
+            , NoOut
+            )
+
+        CloseAll ->
+            ( { model | workspaceItems = WorkspaceItems.empty }
+            , Cmd.none
+            , Emptied
+            )
+
+        CloseWorkspaceItem ref ->
+            let
+                workspaceItems =
+                    WorkspaceItems.remove model.workspaceItems ref
+
+                out =
+                    workspaceItems
+                        |> WorkspaceItems.focusedReference
+                        |> MaybeE.unwrap Emptied FocusOn
+            in
+            ( { model | workspaceItems = workspaceItems }, Cmd.none, out )
+
+        ToggleMinimap ->
+            ( { model | isMinimapToggled = not model.isMinimapToggled }, Cmd.none, NoOut )
+
+        ToggleFold ref ->
+            ( { model
+                | collapsedItems =
+                    SetE.toggle
+                        (WorkspaceItemRef.toString ref)
+                        model.collapsedItems
+              }
+            , Cmd.none
+            , NoOut
+            )
+
+        ChangeDefinitionItemTab wsRef newTab ->
+            let
+                workspaceItems_ =
+                    WorkspaceItems.updateDefinitionItemState
+                        (\s -> { s | activeTab = newTab })
+                        wsRef
+                        model.workspaceItems
+            in
+            ( { model | workspaceItems = workspaceItems_ }, Cmd.none, NoOut )
+
+        ToggleCodeFold wsRef ->
+            let
+                workspaceItems_ =
+                    WorkspaceItems.updateDefinitionItemState
+                        (\s -> { s | isCodeFolded = not s.isCodeFolded })
+                        wsRef
+                        model.workspaceItems
+            in
+            ( { model | workspaceItems = workspaceItems_ }, Cmd.none, NoOut )
+
+        ChangeDependentsItemTab wsRef newTab ->
+            let
+                workspaceItems_ =
+                    WorkspaceItems.updateDependentsItemState
+                        (\s -> { s | activeTab = newTab })
+                        wsRef
+                        model.workspaceItems
+            in
+            ( { model | workspaceItems = workspaceItems_ }, Cmd.none, NoOut )
+
+        OpenDefinition r ->
+            openDefinition config paneId model r
+
+        ShowDependentsOf defRef ->
+            case defRef of
+                WorkspaceItemRef.DefinitionItemRef r ->
+                    openDependents config paneId model r
+
+                _ ->
+                    ( model, Cmd.none, NoOut )
+
+        FetchDependentsFinished depRef defRef (Ok ( defItem, dependents )) ->
+            let
+                workspaceItems =
+                    WorkspaceItems.replace
+                        model.workspaceItems
+                        depRef
+                        (WorkspaceItem.Success
+                            depRef
+                            (WorkspaceItem.DependentsWorkspaceItem
+                                defRef
+                                (DependentsWorkspaceItemState.init DependentsWorkspaceItemState.TermsTab)
+                                defItem
+                                dependents
+                            )
+                        )
+            in
+            ( { model | workspaceItems = workspaceItems }, Cmd.none, NoOut )
+
+        FetchDependentsFinished depRef _ (Err e) ->
+            ( { model
+                | workspaceItems =
+                    WorkspaceItems.replace
+                        model.workspaceItems
+                        depRef
+                        (WorkspaceItem.Failure depRef e)
+              }
+            , Cmd.none
+            , NoOut
+            )
+
+        ToggleDocFold wsRef foldId ->
+            let
+                updateState state =
+                    { state | docFoldToggles = Doc.toggleFold state.docFoldToggles foldId }
+
+                workspaceItems_ =
+                    WorkspaceItems.updateDefinitionItemState
+                        updateState
+                        wsRef
+                        model.workspaceItems
+            in
+            ( { model | workspaceItems = workspaceItems_ }, Cmd.none, NoOut )
+
+        ToggleNamespaceDropdown wsRef ->
+            let
+                updateState state =
+                    { state
+                        | namespaceDropdownIsOpen =
+                            not state.namespaceDropdownIsOpen
+                    }
+
+                workspaceItems_ =
+                    WorkspaceItems.updateDefinitionItemState
+                        updateState
+                        wsRef
+                        model.workspaceItems
+            in
+            ( { model | workspaceItems = workspaceItems_ }, Cmd.none, NoOut )
+
+        SetFocusedItem wsRef ->
+            ( { model | workspaceItems = WorkspaceItems.focusOn model.workspaceItems wsRef }
+            , Cmd.none
+            , FocusOn wsRef
+            )
+
+        FindWithinNamespace wsRef fqn ->
+            let
+                workspaceItems_ =
+                    WorkspaceItems.updateDefinitionItemState
+                        (\s -> { s | namespaceDropdownIsOpen = False })
+                        wsRef
+                        model.workspaceItems
+            in
+            ( { model | workspaceItems = workspaceItems_ }
+            , Cmd.none
+            , RequestFindInNamespace fqn
+            )
+
+        ChangePerspective wsRef ref fqn ->
+            let
+                workspaceItems_ =
+                    WorkspaceItems.updateDefinitionItemState
+                        (\s -> { s | namespaceDropdownIsOpen = False })
+                        wsRef
+                        model.workspaceItems
+            in
+            ( { model | workspaceItems = workspaceItems_ }
+            , Cmd.none
+            , RequestChangePerspective ref fqn
+            )
+
+        UpdateDependentsSearchQuery wsRef query ->
+            let
+                workspaceItems_ =
+                    WorkspaceItems.updateDependentsItemState
+                        (\s -> { s | searchQuery = query })
+                        wsRef
+                        model.workspaceItems
+            in
+            ( { model | workspaceItems = workspaceItems_ }
+            , Cmd.none
+            , NoOut
+            )
+
+        Keydown event ->
+            let
+                ( keyboardShortcut, kCmd ) =
+                    KeyboardShortcut.collect model.keyboardShortcut event.key
+
+                shortcut =
+                    KeyboardShortcut.fromKeyboardEvent model.keyboardShortcut event
+
+                ( nextModel, cmd, out ) =
+                    handleKeyboardShortcut paneId
+                        { model | keyboardShortcut = keyboardShortcut }
+                        shortcut
+            in
+            ( nextModel, Cmd.batch [ cmd, Cmd.map KeyboardShortcutMsg kCmd ], out )
+
+        KeyboardShortcutMsg kMsg ->
+            let
+                ( keyboardShortcut, cmd ) =
+                    KeyboardShortcut.update kMsg model.keyboardShortcut
+            in
+            ( { model | keyboardShortcut = keyboardShortcut }, Cmd.map KeyboardShortcutMsg cmd, NoOut )
+
+        DefinitionSummaryTooltipMsg tMsg ->
+            let
+                ( definitionSummaryTooltip, tCmd ) =
+                    DefinitionSummaryTooltip.update config tMsg model.definitionSummaryTooltip
+            in
+            ( { model | definitionSummaryTooltip = definitionSummaryTooltip }
+            , Cmd.map DefinitionSummaryTooltipMsg tCmd
+            , NoOut
+            )
+
+        _ ->
+            ( model, Cmd.none, NoOut )
+
+
+
+-- HELPERS
+
+
+openDefinition : Config -> String -> Model -> Reference -> ( Model, Cmd Msg, OutMsg )
+openDefinition config paneId ({ workspaceItems } as model) ref =
+    let
+        wsRef =
+            WorkspaceItemRef.DefinitionItemRef ref
+    in
+    -- openItem config paneId model (Just relativeToRef) ref
+    -- We don't want to refetch or replace any already open definitions, but we
+    -- do want to focus and scroll to it (unless its already currently focused)
+    if WorkspaceItems.includesItem workspaceItems wsRef then
+        focusOpenedItem paneId model wsRef
+
+    else
+        let
+            toInsert =
+                WorkspaceItem.Loading wsRef
+
+            nextWorkspaceItems =
+                case workspaceItems |> WorkspaceItems.focus |> Maybe.map WorkspaceItem.reference of
+                    Nothing ->
+                        WorkspaceItems.prependWithFocus workspaceItems toInsert
+
+                    Just r ->
+                        WorkspaceItems.insertWithFocusBefore workspaceItems r toInsert
+        in
+        ( { model | workspaceItems = nextWorkspaceItems }
+        , Cmd.batch [ HttpApi.perform config.api (fetchDefinition config ref), scrollToItem paneId wsRef ]
+        , FocusOn wsRef
+        )
+
+
+focusOpenedItem : String -> Model -> WorkspaceItemRef -> ( Model, Cmd Msg, OutMsg )
+focusOpenedItem paneId ({ workspaceItems } as model) wsRef =
+    if not (WorkspaceItems.isFocused workspaceItems wsRef) then
+        let
+            nextWorkspaceItems =
+                WorkspaceItems.focusOn workspaceItems wsRef
+        in
+        ( { model | workspaceItems = nextWorkspaceItems }
+        , scrollToItem paneId wsRef
+        , FocusOn wsRef
+        )
+
+    else
+        ( model, Cmd.none, NoOut )
+
+
+openDependents : Config -> String -> Model -> Reference -> ( Model, Cmd Msg, OutMsg )
+openDependents config paneId ({ workspaceItems } as model) dependentsOfRef =
+    let
+        depRef =
+            WorkspaceItemRef.DependentsItemRef dependentsOfRef
+    in
+    if WorkspaceItems.includesItem workspaceItems depRef then
+        focusOpenedItem paneId model depRef
+
+    else
+        let
+            nextWorkspaceItems =
+                WorkspaceItems.insertWithFocusBefore
+                    workspaceItems
+                    (WorkspaceItemRef.DefinitionItemRef dependentsOfRef)
+                    (WorkspaceItem.Loading depRef)
+        in
+        ( { model | workspaceItems = nextWorkspaceItems }
+        , Cmd.batch
+            [ fetchDependents config depRef dependentsOfRef
+            , scrollToItem paneId depRef
+            ]
+        , FocusOn depRef
+        )
+
+
+currentlyOpenReferences : Model -> List Reference
+currentlyOpenReferences model =
+    WorkspaceItems.definitionReferences model.workspaceItems
+
+
+currentlyOpenFqns : Model -> List FQN
+currentlyOpenFqns model =
+    WorkspaceItems.fqns model.workspaceItems
+
+
+handleKeyboardShortcut : String -> Model -> KeyboardShortcut -> ( Model, Cmd Msg, OutMsg )
+handleKeyboardShortcut paneId model shortcut =
+    let
+        scrollToCmd =
+            WorkspaceItems.focus
+                >> Maybe.map WorkspaceItem.reference
+                >> Maybe.map (scrollToItem paneId)
+                >> Maybe.withDefault Cmd.none
+
+        nextDefinition =
+            let
+                next =
+                    WorkspaceItems.next model.workspaceItems
+
+                out =
+                    next
+                        |> WorkspaceItems.focusedReference
+                        |> Maybe.map FocusOn
+                        |> Maybe.withDefault NoOut
+            in
+            ( { model | workspaceItems = next }, scrollToCmd next, out )
+
+        prevDefinition =
+            let
+                prev =
+                    WorkspaceItems.prev model.workspaceItems
+
+                out =
+                    prev
+                        |> WorkspaceItems.focusedReference
+                        |> Maybe.map FocusOn
+                        |> Maybe.withDefault NoOut
+            in
+            ( { model | workspaceItems = prev }, scrollToCmd prev, out )
+
+        moveDown =
+            let
+                next =
+                    WorkspaceItems.moveDown model.workspaceItems
+            in
+            ( { model | workspaceItems = next }, scrollToCmd next, NoOut )
+
+        moveUp =
+            let
+                next =
+                    WorkspaceItems.moveUp model.workspaceItems
+            in
+            ( { model | workspaceItems = next }, scrollToCmd next, NoOut )
+    in
+    case shortcut of
+        Chord Shift ArrowDown ->
+            moveDown
+
+        Chord Shift ArrowUp ->
+            moveUp
+
+        Chord Shift (J _) ->
+            moveDown
+
+        Chord Shift (K _) ->
+            moveUp
+
+        Chord Shift (X _) ->
+            ( { model | workspaceItems = WorkspaceItems.empty }
+            , Cmd.none
+            , Emptied
+            )
+
+        Sequence _ ArrowDown ->
+            nextDefinition
+
+        Sequence _ (J _) ->
+            nextDefinition
+
+        Sequence _ ArrowUp ->
+            prevDefinition
+
+        Sequence _ (K _) ->
+            prevDefinition
+
+        Sequence _ (X _) ->
+            let
+                without =
+                    model.workspaceItems
+                        |> WorkspaceItems.focus
+                        |> Maybe.map (WorkspaceItem.reference >> WorkspaceItems.remove model.workspaceItems)
+                        |> Maybe.withDefault model.workspaceItems
+
+                out =
+                    without
+                        |> WorkspaceItems.focusedReference
+                        |> Maybe.map FocusOn
+                        |> Maybe.withDefault Emptied
+            in
+            ( { model | workspaceItems = without }
+            , Cmd.none
+            , out
+            )
+
+        Sequence _ (Z _) ->
+            let
+                collapsedItems =
+                    model.workspaceItems
+                        |> WorkspaceItems.focus
+                        |> Maybe.map WorkspaceItem.reference
+                        |> Maybe.map WorkspaceItemRef.toString
+                        |> Maybe.map (\r -> SetE.toggle r model.collapsedItems)
+                        |> Maybe.withDefault model.collapsedItems
+            in
+            ( { model | collapsedItems = collapsedItems }
+            , Cmd.none
+            , NoOut
+            )
+
+        Chord Shift (Z _) ->
+            let
+                collapsedItems =
+                    if Set.isEmpty model.collapsedItems then
+                        model.workspaceItems
+                            |> WorkspaceItems.toList
+                            |> List.map WorkspaceItem.reference
+                            |> List.map WorkspaceItemRef.toString
+                            |> Set.fromList
+
+                    else
+                        Set.empty
+            in
+            ( { model | collapsedItems = collapsedItems }
+            , Cmd.none
+            , NoOut
+            )
+
+        _ ->
+            ( model, Cmd.none, NoOut )
+
+
+
+-- EFFECTS
+
+
+fetchDefinition : Config -> Reference -> ApiRequest DefinitionItem Msg
+fetchDefinition config ref =
+    let
+        endpoint =
+            CodebaseApi.Definition
+                { perspective = config.perspective
+                , ref = ref
+                }
+    in
+    endpoint
+        |> config.toApiEndpoint
+        |> HttpApi.toRequest
+            (DefinitionItem.decode ref)
+            (FetchDefinitionItemFinished ref)
+
+
+fetchDependents : Config -> WorkspaceItemRef -> Reference -> Cmd Msg
+fetchDependents config depRef defRef =
+    let
+        deps =
+            CodebaseApi.Dependents { ref = defRef }
+                |> config.toApiEndpoint
+                |> HttpApi.toTask config.api.url
+                    (Decode.field "results" DefinitionMatch.decodeList)
+
+        def =
+            CodebaseApi.Definition
+                { perspective = config.perspective
+                , ref = defRef
+                }
+                |> config.toApiEndpoint
+                |> HttpApi.toTask config.api.url
+                    (DefinitionItem.decode defRef)
+
+        t =
+            Task.map2 Tuple.pair def deps
+    in
+    Task.attempt (FetchDependentsFinished depRef defRef) t
+
+
+scrollToItem : String -> WorkspaceItemRef -> Cmd Msg
+scrollToItem paneId ref =
+    let
+        targetId =
+            "workspace-card_" ++ WorkspaceItemRef.toDomString ref
+    in
+    -- Annoying magic number, but this is 0.75rem AKA 12px for scroll margin
+    -- `scroll-margin-top` does not work with Elm's way of setting the viewport
+    ScrollTo.scrollTo_ NoOp paneId targetId 12
+
+
+
+-- SUBSCRIPTIONS
+
+
+subscriptions : Model -> Sub Msg
+subscriptions _ =
+    KeyboardEvent.subscribe KeyboardEvent.Keydown Keydown
+
+
+
+-- VIEW
+
+
+type alias PaneConfig =
+    { paneId : String
+    , operatingSystem : OperatingSystem
+    , isFocused : Bool
+    , withFocusedPaneIndicator : Bool
+    , withDependents : Bool
+    , withDependencies : Bool
+    , withNamespaceDropdown : Bool
+    }
+
+
+syntaxConfig : DefinitionSummaryTooltip.Model -> SyntaxConfig.SyntaxConfig Msg
+syntaxConfig definitionSummaryTooltip =
+    SyntaxConfig.default
+        (OpenDefinition >> Click.onClick)
+        (DefinitionSummaryTooltip.tooltipConfig
+            DefinitionSummaryTooltipMsg
+            definitionSummaryTooltip
+        )
+        |> SyntaxConfig.withSyntaxHelp
+
+
+viewItem : PaneConfig -> Set String -> DefinitionSummaryTooltip.Model -> WorkspaceItem -> Bool -> Html Msg
+viewItem cfg collapsedItems definitionSummaryTooltip item isFocused =
+    let
+        cardBase =
+            WorkspaceCard.empty
+
+        domId =
+            "workspace-card_" ++ (item |> WorkspaceItem.reference |> WorkspaceItemRef.toDomString)
+
+        card =
+            case item of
+                WorkspaceItem.Loading _ ->
+                    cardBase
+                        |> WorkspaceCard.withTitlebarLeft
+                            [ Placeholder.text |> Placeholder.withLength Placeholder.Medium |> Placeholder.view
+                            ]
+                        |> WorkspaceCard.withContent
+                            [ div [ class "workspace-card_loading" ]
+                                [ Placeholder.text |> Placeholder.withLength Placeholder.Medium |> Placeholder.view
+                                , Placeholder.text |> Placeholder.withLength Placeholder.Huge |> Placeholder.view
+                                , Placeholder.text |> Placeholder.withLength Placeholder.Large |> Placeholder.view
+                                , Placeholder.text |> Placeholder.withLength Placeholder.Medium |> Placeholder.view
+                                , Placeholder.text |> Placeholder.withLength Placeholder.Small |> Placeholder.view
+                                ]
+                            ]
+
+                WorkspaceItem.Success wsRef (WorkspaceItem.DefinitionWorkspaceItem definitionRef state defItem) ->
+                    let
+                        namespaceDropdown =
+                            if cfg.withNamespaceDropdown then
+                                Just
+                                    { toggle = ToggleNamespaceDropdown wsRef
+                                    , findWithinNamespace = FindWithinNamespace wsRef
+                                    , changePerspective = ChangePerspective wsRef definitionRef
+                                    }
+
+                            else
+                                Nothing
+
+                        config =
+                            { wsRef = wsRef
+                            , definitionRef = definitionRef
+                            , state = state
+                            , item = defItem
+                            , syntaxConfig = syntaxConfig definitionSummaryTooltip
+                            , closeItem = CloseWorkspaceItem wsRef
+                            , codeAndDocsViewMode =
+                                WorkspaceDefinitionItemCard.MixedCodeAndDocs { toggleCodeFold = ToggleCodeFold wsRef }
+                            , toggleDocFold = ToggleDocFold wsRef
+                            , isFolded =
+                                Set.member
+                                    (WorkspaceItemRef.toString wsRef)
+                                    collapsedItems
+                            , toggleFold = ToggleFold wsRef
+                            , withDependents = cfg.withDependents
+                            , withDependencies = cfg.withDependencies
+                            , showDependents = ShowDependentsOf wsRef
+                            , namespaceDropdown = namespaceDropdown
+                            }
+                    in
+                    WorkspaceDefinitionItemCard.view config
+
+                WorkspaceItem.Success wsRef (WorkspaceItem.DependentsWorkspaceItem dependentsOfRef state defItem dependents) ->
+                    let
+                        config =
+                            { wsRef = wsRef
+                            , dependentsOfRef = dependentsOfRef
+                            , item = defItem
+                            , state = state
+                            , updateQuery = UpdateDependentsSearchQuery wsRef
+                            , changeTab = ChangeDependentsItemTab wsRef
+                            , dependents = dependents
+                            , closeItem = CloseWorkspaceItem wsRef
+                            , openDefinition = OpenDefinition
+                            }
+                    in
+                    WorkspaceDependentsItemCard.view config
+
+                WorkspaceItem.Success _ _ ->
+                    {- TODO -}
+                    cardBase
+                        |> WorkspaceCard.withContent []
+
+                WorkspaceItem.Failure wsRef e ->
+                    let
+                        ( title, subTitle ) =
+                            case wsRef of
+                                WorkspaceItemRef.DefinitionItemRef _ ->
+                                    ( WorkspaceItemRef.toHumanString wsRef
+                                    , "failed to load definition"
+                                    )
+
+                                WorkspaceItemRef.DependentsItemRef _ ->
+                                    ( WorkspaceItemRef.toHumanString wsRef
+                                    , "failed to load dependents"
+                                    )
+
+                                _ ->
+                                    ( WorkspaceItemRef.toHumanString wsRef
+                                    , "failed to load"
+                                    )
+                    in
+                    cardBase
+                        |> WorkspaceCard.withTitlebarLeft
+                            [ StatusIndicator.bad |> StatusIndicator.view
+                            , strong [] [ text title ]
+                            , strong [ class "subdued" ] [ text subTitle ]
+                            ]
+                        |> WorkspaceCard.withTitlebarRight
+                            [ Button.icon (CloseWorkspaceItem wsRef) Icon.x
+                                |> Button.subdued
+                                |> Button.small
+                                |> Button.view
+                            ]
+                        |> WorkspaceCard.withContent
+                            [ div [ class "workspace-card_error" ]
+                                [ p [ class "error" ]
+                                    [ pre [] [ text (Util.httpErrorToString e) ]
+                                    ]
+                                , Button.iconThenLabel (Refetch wsRef) Icon.refresh "Try again"
+                                    |> Button.small
+                                    |> Button.view
+                                ]
+                            ]
+    in
+    card
+        |> WorkspaceCard.withFocus isFocused
+        |> WorkspaceCard.withDomId domId
+        |> WorkspaceCard.withClick
+            (Click.onClick (SetFocusedItem (WorkspaceItem.reference item)))
+        |> WorkspaceCard.view cfg.operatingSystem
+
+
+view : PaneConfig -> Model -> Html Msg
+view cfg model =
+    let
+        minimap =
+            if WorkspaceItems.length model.workspaceItems > 1 then
+                WorkspaceMinimap.view
+                    { keyboardShortcut = model.keyboardShortcut
+                    , workspaceItems = model.workspaceItems
+                    , selectItemMsg = SetFocusedItem
+                    , closeAllMsg = CloseAll
+                    , closeItemMsg = CloseWorkspaceItem
+                    , isToggled = model.isMinimapToggled
+                    , toggleMinimapMsg = ToggleMinimap
+                    }
+
+            else
+                UI.nothing
+    in
+    div
+        [ onClick PaneFocus
+        , class "workspace-pane"
+        , id cfg.paneId
+        , classList
+            [ ( "workspace-pane_focused", cfg.isFocused )
+            , ( "workspace-pane_focused-pane-indicator", cfg.withFocusedPaneIndicator )
+            ]
+        ]
+        (minimap
+            :: (model.workspaceItems
+                    |> WorkspaceItems.mapToList (viewItem cfg model.collapsedItems model.definitionSummaryTooltip)
+               )
+        )

--- a/src/Code2/Workspace/WorkspacePanes.elm
+++ b/src/Code2/Workspace/WorkspacePanes.elm
@@ -1,0 +1,334 @@
+module Code2.Workspace.WorkspacePanes exposing (..)
+
+import Code.Config exposing (Config)
+import Code.Definition.Reference exposing (Reference)
+import Code.FullyQualifiedName exposing (FQN)
+import Code2.Workspace.WorkspaceItemRef exposing (WorkspaceItemRef)
+import Code2.Workspace.WorkspacePane as WorkspacePane
+import Html exposing (Html, div)
+import Html.Attributes exposing (class)
+import Lib.OperatingSystem exposing (OperatingSystem)
+import SplitPane.SplitPane as SplitPane
+
+
+type FocusedPane
+    = LeftPaneFocus { rightPaneVisible : Bool }
+    | RightPaneFocus
+
+
+type alias Model =
+    { left : WorkspacePane.Model
+    , right : WorkspacePane.Model
+    , focusedPane : FocusedPane
+    , splitPane : SplitPane.State
+    }
+
+
+init : OperatingSystem -> ( Model, Cmd Msg )
+init os =
+    let
+        ( leftPane, leftPaneCmd ) =
+            WorkspacePane.init os
+
+        ( rightPane, rightPaneCmd ) =
+            WorkspacePane.init os
+
+        splitPane =
+            SplitPane.init SplitPane.Horizontal
+                |> SplitPane.configureSplitter (SplitPane.percentage 0.5 Nothing)
+
+        panes =
+            { left = leftPane
+            , right = rightPane
+            , focusedPane = LeftPaneFocus { rightPaneVisible = False }
+            , splitPane = splitPane
+            }
+    in
+    ( panes
+    , Cmd.batch
+        [ Cmd.map LeftPaneMsg leftPaneCmd
+        , Cmd.map RightPaneMsg
+            rightPaneCmd
+        ]
+    )
+
+
+
+-- UPDATE
+
+
+type Msg
+    = LeftPaneMsg WorkspacePane.Msg
+    | RightPaneMsg WorkspacePane.Msg
+    | SplitPaneMsg SplitPane.Msg
+
+
+type OutMsg
+    = NoOut
+    | Focused WorkspaceItemRef
+    | Emptied
+    | ChangePerspectiveToSubNamespace Reference FQN
+    | ShowFinderRequest FQN
+
+
+update : Config -> Msg -> Model -> ( Model, Cmd Msg, OutMsg )
+update config msg model =
+    case msg of
+        LeftPaneMsg workspacePaneMsg ->
+            let
+                ( leftPane, leftPaneCmd, leftPaneOut ) =
+                    WorkspacePane.update config "workspace-pane_left" workspacePaneMsg model.left
+
+                ( model_, out ) =
+                    case leftPaneOut of
+                        WorkspacePane.RequestPaneFocus ->
+                            case model.focusedPane of
+                                RightPaneFocus ->
+                                    ( { model | focusedPane = LeftPaneFocus { rightPaneVisible = True } }, NoOut )
+
+                                _ ->
+                                    ( model, NoOut )
+
+                        WorkspacePane.FocusOn wsRef ->
+                            ( model, Focused wsRef )
+
+                        WorkspacePane.RequestFindInNamespace fqn ->
+                            ( model, ShowFinderRequest fqn )
+
+                        WorkspacePane.Emptied ->
+                            ( model, Emptied )
+
+                        WorkspacePane.RequestChangePerspective ref fqn ->
+                            ( model, ChangePerspectiveToSubNamespace ref fqn )
+
+                        _ ->
+                            ( model, NoOut )
+            in
+            ( { model_ | left = leftPane }
+            , Cmd.map LeftPaneMsg leftPaneCmd
+            , out
+            )
+
+        RightPaneMsg workspacePaneMsg ->
+            let
+                ( rightPane, rightPaneCmd, rightPaneOut ) =
+                    WorkspacePane.update config "workspace-pane_right" workspacePaneMsg model.left
+
+                ( model_, out ) =
+                    case rightPaneOut of
+                        WorkspacePane.RequestPaneFocus ->
+                            case model.focusedPane of
+                                RightPaneFocus ->
+                                    ( { model | focusedPane = RightPaneFocus }, NoOut )
+
+                                _ ->
+                                    ( model, NoOut )
+
+                        WorkspacePane.FocusOn wsRef ->
+                            ( model, Focused wsRef )
+
+                        WorkspacePane.RequestFindInNamespace fqn ->
+                            ( model, ShowFinderRequest fqn )
+
+                        WorkspacePane.Emptied ->
+                            ( model, Emptied )
+
+                        _ ->
+                            ( model, NoOut )
+            in
+            ( { model_ | right = rightPane }
+            , Cmd.map RightPaneMsg rightPaneCmd
+            , out
+            )
+
+        SplitPaneMsg paneMsg ->
+            ( { model
+                | splitPane =
+                    SplitPane.update
+                        paneMsg
+                        model.splitPane
+              }
+            , Cmd.none
+            , NoOut
+            )
+
+
+toggleRightPane : Model -> Model
+toggleRightPane model =
+    let
+        focus =
+            case model.focusedPane of
+                LeftPaneFocus _ ->
+                    RightPaneFocus
+
+                RightPaneFocus ->
+                    LeftPaneFocus { rightPaneVisible = False }
+    in
+    { model | focusedPane = focus }
+
+
+focusRight : Model -> Model
+focusRight model =
+    let
+        focus =
+            case model.focusedPane of
+                LeftPaneFocus { rightPaneVisible } ->
+                    if rightPaneVisible then
+                        RightPaneFocus
+
+                    else
+                        model.focusedPane
+
+                _ ->
+                    model.focusedPane
+    in
+    { model | focusedPane = focus }
+
+
+focusLeft : Model -> Model
+focusLeft model =
+    let
+        focus =
+            case model.focusedPane of
+                LeftPaneFocus _ ->
+                    model.focusedPane
+
+                RightPaneFocus ->
+                    LeftPaneFocus { rightPaneVisible = True }
+    in
+    { model | focusedPane = focus }
+
+
+openDefinition : Config -> Model -> Reference -> ( Model, Cmd Msg )
+openDefinition config model ref =
+    case model.focusedPane of
+        LeftPaneFocus _ ->
+            let
+                -- TODO: deal with the out msg and routes
+                ( leftPane, leftPaneCmd, _ ) =
+                    WorkspacePane.openDefinition config "workspace-pane_left" model.left ref
+            in
+            ( { model | left = leftPane }, Cmd.map LeftPaneMsg leftPaneCmd )
+
+        RightPaneFocus ->
+            let
+                ( rightPane, rightPaneCmd, _ ) =
+                    WorkspacePane.openDefinition config "workspace-pane_right" model.right ref
+            in
+            ( { model | right = rightPane }, Cmd.map RightPaneMsg rightPaneCmd )
+
+
+openDependentsOf : Config -> Model -> Reference -> ( Model, Cmd Msg )
+openDependentsOf config model ref =
+    case model.focusedPane of
+        LeftPaneFocus _ ->
+            let
+                -- TODO: deal with the out msg and routes
+                ( leftPane, leftPaneCmd, _ ) =
+                    WorkspacePane.openDependents config "workspace-pane_left" model.left ref
+            in
+            ( { model | left = leftPane }, Cmd.map LeftPaneMsg leftPaneCmd )
+
+        RightPaneFocus ->
+            let
+                ( rightPane, rightPaneCmd, _ ) =
+                    WorkspacePane.openDependents config "workspace-pane_right" model.right ref
+            in
+            ( { model | right = rightPane }, Cmd.map RightPaneMsg rightPaneCmd )
+
+
+currentlyOpenReferences : Model -> List Reference
+currentlyOpenReferences model =
+    WorkspacePane.currentlyOpenReferences model.left
+        ++ WorkspacePane.currentlyOpenReferences model.left
+
+
+currentlyOpenFqns : Model -> List FQN
+currentlyOpenFqns model =
+    WorkspacePane.currentlyOpenFqns model.left
+        ++ WorkspacePane.currentlyOpenFqns model.right
+
+
+
+-- SUBSCRIPTIONS
+
+
+subscriptions : Model -> Sub Msg
+subscriptions model =
+    let
+        focusSub =
+            case model.focusedPane of
+                LeftPaneFocus _ ->
+                    Sub.map LeftPaneMsg (WorkspacePane.subscriptions model.left)
+
+                RightPaneFocus ->
+                    Sub.map RightPaneMsg (WorkspacePane.subscriptions model.right)
+    in
+    Sub.batch
+        [ focusSub
+        , Sub.map SplitPaneMsg (SplitPane.subscriptions model.splitPane)
+        ]
+
+
+
+-- VIEW
+
+
+type alias PanesConfig =
+    { operatingSystem : OperatingSystem
+    , withDependents : Bool
+    , withDependencies : Bool
+    , withFocusedPaneIndicator : Bool
+    , withNamespaceDropdown : Bool
+    }
+
+
+view : PanesConfig -> Model -> Html Msg
+view cfg model =
+    let
+        paneConfig paneId isFocused =
+            { operatingSystem = cfg.operatingSystem
+            , withDependents = cfg.withDependents
+            , withDependencies = cfg.withDependencies
+            , paneId = paneId
+            , isFocused = isFocused
+            , withFocusedPaneIndicator = cfg.withFocusedPaneIndicator
+            , withNamespaceDropdown = cfg.withNamespaceDropdown
+            }
+
+        left isFocused =
+            Html.map LeftPaneMsg
+                (WorkspacePane.view
+                    (paneConfig "workspace-pane_left" isFocused)
+                    model.left
+                )
+
+        right isFocused =
+            Html.map RightPaneMsg
+                (WorkspacePane.view
+                    (paneConfig "workspace-pane_right" isFocused)
+                    model.right
+                )
+
+        splitConfig =
+            SplitPane.createViewConfig
+                { toMsg = SplitPaneMsg
+                , customSplitter =
+                    Just (SplitPane.createCustomSplitter SplitPaneMsg splitter)
+                }
+
+        splitter =
+            { attributes = [ class "workspace-panes_resize-handle" ]
+            , children = []
+            }
+    in
+    case model.focusedPane of
+        LeftPaneFocus { rightPaneVisible } ->
+            if rightPaneVisible then
+                div [ class "workspace-panes" ] [ SplitPane.view splitConfig (left True) (right False) model.splitPane ]
+
+            else
+                div [ class "workspace-panes_single-pane" ] [ left True ]
+
+        RightPaneFocus ->
+            div [ class "workspace-panes" ] [ SplitPane.view splitConfig (left False) (right True) model.splitPane ]

--- a/src/UnisonShare/AppContext.elm
+++ b/src/UnisonShare/AppContext.elm
@@ -86,9 +86,9 @@ lastActiveNotificationsTabToString tab =
 
 
 toCodeConfig : AppContext -> CodeBrowsingContext -> Perspective -> Code.Config.Config
-toCodeConfig appContex codeBrowsingContext perspective =
+toCodeConfig appContex context perspective =
     { operatingSystem = appContex.operatingSystem
     , perspective = perspective
-    , toApiEndpoint = Api.codebaseApiEndpointToEndpoint codeBrowsingContext
+    , toApiEndpoint = Api.codebaseApiEndpointToEndpoint context
     , api = appContex.api
     }

--- a/src/css/code2.css
+++ b/src/css/code2.css
@@ -1,0 +1,6 @@
+@import "./code2/workspace/workspace-panes.css";
+@import "./code2/workspace/workspace-pane.css";
+@import "./code2/workspace/workspace-card.css";
+@import "./code2/workspace/workspace-dependents-item-card.css";
+@import "./code2/workspace/workspace-definition-item-card.css";
+@import "./code2/workspace/workspace-minimap.css";

--- a/src/css/code2/workspace/workspace-card.css
+++ b/src/css/code2/workspace/workspace-card.css
@@ -1,0 +1,245 @@
+.workspace-card {
+  --c-workspace-card_border: var(--u-color_border_subdued);
+  --c-workspace-card_background: var(--u-color_container_faded);
+  --c-workspace-card_width: min(
+    calc(var(--readable-column-width-medium) + 2rem),
+    100%
+  );
+
+  .definition-doc {
+    --color-doc-source-bg: var(--u-color_container_subdued);
+  }
+
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  padding: 0;
+  width: var(--c-workspace-card_width);
+  position: relative;
+  z-index: var(--layer-base);
+  transition: all 0.2s;
+
+  & .tooltip-with-shortcut {
+    display: flex;
+    flex-direction: row;
+    gap: 0.5rem;
+    align-items: center;
+  }
+
+  & .workspace-card_foldable-content {
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+    padding: 0;
+    transition: height 0.2s ease-in-out;
+    width: 100%;
+    height: auto;
+    height: calc-size(auto, size);
+  }
+
+  & .workspace-card_titlebar {
+    display: flex;
+    flex-direction: row;
+    width: 100%;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.75rem;
+    height: 2.5rem;
+    font-size: var(--font-size-medium);
+    color: var(--u-color_text_subdued);
+    position: relative;
+    transition: none;
+    border-bottom: 1px solid var(--c-workspace-card_border);
+
+    & a:has(.fully-qualified-name):hover .fully-qualified-name_segment {
+      color: var(--u-color_interactive);
+    }
+
+    & .subdued {
+      color: var(--u-color_text_subdued);
+    }
+
+    & .workspace-card_titlebar_left {
+      display: flex;
+      flex-direction: row;
+      gap: 0.5rem;
+      align-items: center;
+
+      & .copy-on-click {
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+        gap: 0.25rem;
+
+        & .copy-on-click_success {
+          position: absolute;
+          background: var(--u-color_positive_element_subdued);
+          width: 1.5rem;
+          height: 1.5rem;
+          border-radius: 4px;
+          display: flex;
+          line-height: 1;
+          align-items: center;
+          justify-content: center;
+
+          & .icon {
+            color: var(--u-color_positive_icon-on-element_subdued);
+            font-size: var(--font-size-base);
+          }
+        }
+      }
+
+      & .tooltip {
+        margin-top: 0.5rem;
+        margin-left: -0.5rem;
+
+        & .tooltip-bubble {
+          height: 2.25rem;
+          display: flex;
+          align-items: center;
+        }
+      }
+    }
+
+    & .workspace-card_titlebar_right {
+      position: absolute;
+      right: 0.325rem;
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+      gap: 0.125rem;
+
+      & .tooltip {
+        margin-top: 0.5rem;
+        margin-left: 2rem;
+
+        & .tooltip-bubble {
+          height: 2.25rem;
+          display: flex;
+          align-items: center;
+        }
+      }
+    }
+
+    & .workspace-card_title {
+      font-weight: bold;
+    }
+  }
+
+  & .workspace-card_titlebar:has(+ .workspace-card_subtitlebar) {
+    border-bottom: 0;
+  }
+
+  & .workspace-card_subtitlebar {
+    display: flex;
+    flex-direction: row;
+    width: 100%;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.75rem;
+    padding-top: 0;
+    font-size: var(--font-size-medium);
+    color: var(--u-color_text_subdued);
+    position: relative;
+    transition: none;
+    border-bottom: 1px solid var(--c-workspace-card_border);
+  }
+
+  & .tab-list {
+    --c-color_tabs_text: var(--u-color_text_subdued);
+    --c-color_tabs_border: var(--color-card-border);
+    --c-color_tabs_text_selected: var(--u-color_text);
+    --c-color_tabs_border_selected: var(--u-color_border_emphasized);
+    --c-color_tabs_text_hovered: var(--u-color_text);
+    --c-color_tabs_border_hovered: var(--color-card-border);
+
+    & .tab {
+      font-weight: 600;
+      font-size: var(--font-size-small);
+    }
+  }
+
+  & .workspace-card_main-content {
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+    padding: 0.75rem;
+    width: 100%;
+    font-size: var(--font-size-medium);
+
+    container-name: doc-container;
+    container-type: inline-size;
+  }
+
+  & .workspace-card_error {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+
+    & .error {
+      font-family: var(--font-monospace);
+    }
+  }
+
+  & .workspace-card_loading {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+}
+
+.workspace-card.card {
+  --color-card-bg: var(--c-workspace-card_background);
+  --color-card-border: var(--c-workspace-card_border);
+}
+
+.workspace-pane_focused .workspace-card.focused {
+  --c-workspace-card_border: var(--u-color_border);
+  --c-workspace-card_background: var(--u-color_container_selected);
+  border-color: var(--u-color_focus-border);
+  box-shadow: 0 0 0 2px var(--u-color_focus-outline);
+
+  & .workspace-card_titlebar {
+    color: var(--u-color_text);
+    background: var(--u-color_container);
+    border-radius: var(--border-radius-base) var(--border-radius-base) 0 0;
+  }
+
+  & .tab-list {
+    --c-color_tabs_border: var(--color-card-border);
+    background: var(--u-color_container);
+  }
+}
+
+.workspace-card:hover {
+  z-index: var(--layer-floating-controls);
+}
+
+.workspace-card:not(.focused):hover {
+  --c-workspace-card_border: var(--u-color_border);
+  --c-workspace-card_background: var(--u-color_container_selected);
+}
+
+.workspace-pane_focused .workspace-card.focused .definition-doc {
+  --color-doc-bg: var(--c-workspace-card_background);
+}
+
+.workspace-card .definition-doc aside {
+  right: -16.5rem;
+}
+
+.workspace-card.folded {
+  border-radius: var(--border-radius-base);
+
+  & .workspace-card_foldable-content {
+    height: 0;
+    overflow: hidden;
+  }
+
+  &.folded .workspace-card_titlebar,
+  & .workspace-card_titlebar {
+    border-bottom: 1px solid transparent;
+    transition: border 0.2s ease-in-out 0.2s;
+    border-radius: var(--border-radius-base);
+  }
+}

--- a/src/css/code2/workspace/workspace-definition-item-card.css
+++ b/src/css/code2/workspace/workspace-definition-item-card.css
@@ -1,0 +1,153 @@
+.workspace-card.workspace-definition-item-card {
+  & .workspace-definition-item-card_other-names {
+    & .workspace-definition-item-card_other-names_button {
+      width: 1.5rem;
+      height: 1.5rem;
+      border-radius: var(--border-radius-base);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+
+      &:hover {
+        & .icon {
+          color: var(--u-color_icon-on-action_hovered);
+        }
+      }
+    }
+
+    & .tooltip {
+      & .tooltip-bubble {
+        height: auto;
+      }
+    }
+  }
+
+  & .workspace-definition-item-card_other-names_list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+
+    & .aka {
+      color: var(--u-color_text_subdued);
+    }
+
+    & .aka,
+    & .other-name {
+      display: flex;
+      line-height: 1;
+      padding: 0.25rem 0;
+    }
+
+    & .other-name {
+      flex-direction: row;
+      gap: 0.25rem;
+      align-items: center;
+
+      & .icon {
+        color: var(--u-color_icon_subdued);
+      }
+
+      & .fully-qualified-name {
+        height: auto;
+        padding: 0;
+      }
+    }
+  }
+
+  & .definition-hash {
+    margin-right: 0.75rem;
+    padding: 0 0.5rem;
+    border-radius: var(--border-radius-base);
+    height: 1.5rem;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    transition: all 0.2s;
+
+    & .tooltip {
+      margin-top: calc(0.25rem - 1px);
+      margin-left: 5.5rem;
+
+      & .tooltip-bubble {
+        height: 2.25rem;
+        display: flex;
+        align-items: center;
+      }
+    }
+
+    & .hash {
+      font-size: var(--font-size-extra-small);
+    }
+
+    & .icon {
+      font-size: var(--font-size-extra-small);
+      transition: none;
+    }
+
+    & .copy-on-click {
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+      gap: 0.25rem;
+
+      & .copy-on-click_success {
+        position: absolute;
+        margin-top: 3px;
+        margin-left: -1.5rem;
+
+        & .icon {
+          color: var(--u-color_positive_icon-on-element_subdued);
+          font-size: var(--font-size-small);
+        }
+      }
+    }
+
+    &:hover {
+      background: var(--u-color_action_hovered);
+
+      & .hash {
+        color: var(--u-color_text);
+      }
+
+      & .icon {
+        color: var(--u-color_icon);
+      }
+    }
+  }
+
+  & .mixed-docs-and-code {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  & .foldable-source {
+    display: flex;
+    flex-direction: row;
+    gap: 0.25rem;
+    align-items: flex-start;
+  }
+}
+
+@container workspace-pane (max-width: 968px) {
+  .workspace-card.workspace-definition-item-card {
+    & .definition-doc aside {
+      position: relative;
+      right: auto;
+      width: auto;
+      margin: 1.5rem 1.5rem 1.5rem 1.5rem;
+    }
+
+    & .definition-source {
+      overflow: auto;
+      overflow-x: auto;
+    }
+
+    & .namespace-dropdown,
+    & .category-icon,
+    & .workspace-definition-item-card_other-names_list,
+    & .definition-hash {
+      display: none;
+    }
+  }
+}

--- a/src/css/code2/workspace/workspace-dependents-item-card.css
+++ b/src/css/code2/workspace/workspace-dependents-item-card.css
@@ -1,0 +1,65 @@
+.workspace-card {
+  &:has(.workspace-dependents-item-card_content) .search-dependents {
+    width: 100%;
+  }
+
+  & .workspace-card_main-content:has(.workspace-dependents-item-card_content) {
+    padding: 0;
+  }
+
+  & .workspace-dependents-item-card_content {
+    display: flex;
+    flex-direction: column;
+    padding: 0;
+    max-height: 18rem;
+    overflow: auto;
+
+    & .empty-state {
+      color: var(--u-color_text_subdued);
+      padding: 1rem;
+      display: flex;
+      gap: 0;
+      flex-direction: column;
+      font-size: var(--font-size-medium);
+
+      & .fully-qualified-name_segment {
+        color: var(--u-color_text_subdued);
+        font-size: var(--font-size-base);
+      }
+    }
+
+    & .dependents_column {
+      display: flex;
+      flex-direction: column;
+      padding: 0.75rem;
+      display: flex;
+      width: 100%;
+
+      & .dependents_items {
+        display: flex;
+        flex-direction: column;
+
+        & .dependent {
+          font-family: var(--font-monospace);
+          margin-left: -0.25rem;
+          padding: 0.25rem;
+          padding-left: 0.5rem;
+          border-radius: var(--border-radius-base);
+
+          & .fully-qualified-name {
+            font-weight: normal;
+            height: auto;
+          }
+
+          &:hover {
+            background: var(--u-color_element_hovered);
+          }
+        }
+      }
+    }
+
+    & .dependents_column:last-child {
+      border: 0;
+    }
+  }
+}

--- a/src/css/code2/workspace/workspace-minimap.css
+++ b/src/css/code2/workspace/workspace-minimap.css
@@ -1,0 +1,182 @@
+/* @color-todo @inverse */
+.workspace-minimap {
+  --c-color_workspace-minimap_background: var(--color-gray-1);
+  --c-color_workspace-minimap_item_hovered: var(--color-gray-2);
+  --c-color_workspace-minimap_item_selected: var(--color-gray-3);
+  --c-color_workspace-minimap_text: var(--color-gray-11);
+  --c-color_workspace-minimap_text_subdued: var(--color-gray-5);
+  --c-color_workspace-minimap_interactive: var(--color-blue-4);
+
+  --u-color_text: var(--c-color_workspace-minimap_text);
+  --u-color_interactive: var(--c-color_workspace-minimap_interactive);
+
+  background: var(--c-color_workspace-minimap_background);
+  border-radius: var(--border-radius-base);
+
+  font-size: var(--font-size-medium);
+}
+
+/* @color-todo @inverse */
+.workspace-minimap .button {
+  --color-button-default-text: var(--color-gray-5);
+  --color-button-default-icon: var(--color-gray-4);
+  --color-button-default-icon-only: var(--color-gray-5);
+  --color-button-default-bg: var(--color-gray-3);
+  --color-button-default-hover-text: var(--color-gray-8);
+  --color-button-default-hover-icon: var(--color-gray-5);
+  --color-button-default-hover-icon-only: var(--color-gray-8);
+  --color-button-default-hover-bg: var(--color-gray-3);
+
+  flex-shrink: 0;
+}
+
+.workspace-minimap_expanded {
+  display: flex;
+  flex-direction: column;
+  min-width: 16rem;
+  padding: 0.75rem;
+  gap: 1rem;
+}
+
+.workspace-minimap_collapsed {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.25rem;
+  gap: 0.25rem;
+}
+
+.workspace-minimap_header {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  font-size: var(--font-size-small);
+  align-items: center;
+}
+
+.workspace-minimap_header .workspace-minimap_header_title {
+  color: var(--c-color_workspace-minimap_text_subdued);
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  line-height: 1;
+  gap: 0.5rem;
+}
+
+.workspace-minimap_header .workspace-minimap_header_title:hover {
+  color: var(--c-color_workspace-minimap_interactive);
+}
+.workspace-minimap_header .workspace-minimap_header_title:hover .icon {
+  color: var(--c-color_workspace-minimap_interactive);
+}
+
+.workspace-minimap_header .workspace-minimap_close {
+  font-weight: bold;
+}
+
+.workspace-minimap_entries {
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+}
+
+.workspace-minimap_item {
+  display: flex;
+  align-items: center;
+  height: 2rem;
+  justify-content: space-between;
+  cursor: pointer;
+  border-radius: var(--border-radius-base);
+  color: var(--c-color_workspace-minimap_text_subdued);
+  padding: 0 0.25rem 0 0.5rem;
+  transition: all 0.2s;
+}
+
+.workspace-minimap_item .button {
+  display: none;
+}
+
+.workspace-minimap_collapsed .workspace-minimap_item {
+  height: 1.5rem;
+}
+
+.workspace-minimap_expanded .workspace-minimap_item.focused {
+  background: var(--c-color_workspace-minimap_item_selected);
+}
+
+.workspace-minimap_expanded .workspace-minimap_item:hover .button {
+  display: inline-flex;
+}
+
+.workspace-minimap_item:not(.focused):hover {
+  background: var(--c-color_workspace-minimap_item_hovered);
+  --u-color_text: var(--c-color_workspace-minimap_interactive);
+}
+
+.workspace-minimap_item .workspace-minimap_item_content {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+}
+
+.workspace-minimap_item .workspace-minimap_item_content .fully-qualified-name {
+  font-weight: normal;
+}
+
+.workspace-minimap_item .workspace-minimap_item_content .icon {
+  line-height: 1;
+}
+
+.workspace-minimap_item .keyboard-shortcut {
+  padding-right: 0.5rem;
+}
+
+/* -- Responsive ----------------------------------------------------------- */
+
+@media only screen and (--u-viewport_min-lg) {
+  .workspace-minimap:not(.workspace-minimap_toggled)
+    .workspace-minimap_collapsed {
+    display: none;
+    opacity: 0;
+  }
+
+  .workspace-minimap:not(.workspace-minimap_toggled)
+    .workspace-minimap_expanded {
+    display: flex;
+    opacity: 1;
+  }
+
+  .workspace-minimap.workspace-minimap_toggled .workspace-minimap_collapsed {
+    display: flex;
+    opacity: 1;
+  }
+
+  .workspace-minimap.workspace-minimap_toggled .workspace-minimap_expanded {
+    display: none;
+    opacity: 0;
+  }
+}
+
+@media only screen and (--u-viewport_max-lg) {
+  .workspace-minimap:not(.workspace-minimap_toggled)
+    .workspace-minimap_collapsed {
+    display: flex;
+    opacity: 1;
+  }
+
+  .workspace-minimap:not(.workspace-minimap_toggled)
+    .workspace-minimap_expanded {
+    display: none;
+    opacity: 0;
+  }
+
+  .workspace-minimap.workspace-minimap_toggled .workspace-minimap_collapsed {
+    display: none;
+    opacity: 0;
+  }
+
+  .workspace-minimap.workspace-minimap_toggled .workspace-minimap_expanded {
+    display: flex;
+    opacity: 1;
+  }
+}

--- a/src/css/code2/workspace/workspace-pane.css
+++ b/src/css/code2/workspace/workspace-pane.css
@@ -1,0 +1,87 @@
+.workspace-pane {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 0.75rem;
+  overflow: auto;
+  width: 100%;
+  container-type: inline-size;
+  container-name: workspace-pane;
+
+  & .error {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 0.25rem;
+
+    & .error_icon {
+      height: 1.25rem;
+      width: 1.25rem;
+      border-radius: 0.65rem;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: var(--u-color_critical_action);
+
+      & .icon {
+        color: var(--u-color_critical_text-on-action);
+        margin-bottom: 3px;
+      }
+    }
+  }
+
+  &:not(.workspace-pane_focused) {
+    opacity: 0.65;
+  }
+
+  /* Focus indicator */
+
+  &.workspace-pane_focused-pane-indicator.workspace-pane_focused::before {
+    content: " ";
+    position: absolute;
+    width: 2rem;
+    height: 2rem;
+    background: var(--u-color_chrome_border);
+    top: 0;
+    right: 0;
+    z-index: var(--layer-beneath);
+  }
+
+  &.workspace-pane_focused-pane-indicator.workspace-pane_focused::after {
+    content: " ";
+    position: absolute;
+    width: 2rem;
+    height: 2rem;
+    border-radius: 0 1rem 0 0;
+    background: var(--u-color_chrome_subdued);
+    top: 0;
+    right: 0;
+    z-index: var(--layer-beneath);
+  }
+
+  &#workspace-pane_right.workspace-pane_focused-pane-indicator.workspace-pane_focused::before {
+    left: 0;
+    right: auto;
+  }
+
+  &#workspace-pane_right.workspace-pane_focused-pane-indicator.workspace-pane_focused::after {
+    left: 1px;
+    right: auto;
+    border-radius: 1rem 0 0 0;
+  }
+
+  & .workspace-minimap {
+    position: absolute;
+    z-index: var(--layer-floating-controls);
+    right: 1rem;
+    max-height: 75%;
+    overflow: auto;
+  }
+}
+
+@media only screen and (--u-viewport_max-xl) {
+  .workspace-pane .workspace-minimap {
+    opacity: 0;
+  }
+}

--- a/src/css/code2/workspace/workspace-panes.css
+++ b/src/css/code2/workspace/workspace-panes.css
@@ -1,0 +1,48 @@
+.workspace-panes,
+.workspace-panes_single-pane {
+  display: flex;
+  flex: 1;
+  width: 100%;
+  height: 100%;
+}
+
+.workspace-panes_resize-handle {
+  width: 1.5rem;
+  z-index: 1;
+  margin-left: -0.75rem;
+  margin-right: -0.75rem;
+  height: 100%;
+  cursor: col-resize;
+  position: relative;
+}
+
+.workspace-panes_resize-handle::before {
+  position: absolute;
+  top: 0;
+  left: 0.75rem;
+  bottom: 0;
+  background: var(--u-color_chrome_border);
+  width: 1px;
+  content: "";
+}
+
+.workspace-panes_resize-handle:hover::before {
+  background: var(--u-color_focus-border);
+}
+
+.workspace-panes .workspace-card {
+  --c-workspace-card_width: 100%;
+}
+
+/* TODO: these are the styles from ui-core. Would be better if it were more
+ * dynamic somehow */
+.workspace-panes .workspace-card aside {
+  position: relative;
+  right: auto;
+  width: auto;
+  margin: 1.5rem 1.5rem 1.5rem 1.5rem;
+}
+
+.workspace-panes .workspace-card_main-content:has(> .rich) {
+  overflow-x: auto;
+}

--- a/src/css/unison-share.css
+++ b/src/css/unison-share.css
@@ -20,3 +20,18 @@
 @import "./unison-share/timeline.css";
 @import "./unison-share/omni-search.css";
 @import "./unison-share/paginated.css";
+@import "./code2.css";
+
+/* TODO: put back into ui-core */
+:root {
+  --u-color_icon_very-subdued: var(--color-gray-6);
+  --u-color_chrome: var(--color-gray-9);
+  --u-color_chrome_subdued: var(--color-gray-10);
+  --u-color_chrome_emphasized: var(--color-gray-11);
+  --u-color_chrome_selected: var(--color-gray-10);
+  --u-color_chrome_border: var(--u-color_border);
+}
+
+.workspace-pane_focused .workspace-card.focused {
+  --c-workspace-card_background: var(--color-gray-11);
+}

--- a/src/css/unison-share/page/code-page.css
+++ b/src/css/unison-share/page/code-page.css
@@ -92,3 +92,13 @@
   display: flex;
   flex-grow: 1;
 }
+
+.code-page .sidebar-toggled .columns {
+  padding-top: 2.25rem;
+}
+
+@media only screen and (--u-viewport_max-lg) {
+  .code-page .columns {
+    padding-top: 1.25rem;
+  }
+}


### PR DESCRIPTION
Port the "Workspace" modules from UCM Desktop to Share (eventually planned to be fully shared via ui-core), and with it the ability to render other items in the Workspace than just definitions. The first of which is a new Dependents card that lists the dependents of a definition.

This includes a considerable amount of configurable modules to allow for both UCM Desktop and Share to have their unique configuration of features (though they are possible going to get closer in time).