### PR TITLE
swap the Notification.Read and Unread positions

### DIFF
--- a/src/UnisonShare/Page/NotificationsPage.elm
+++ b/src/UnisonShare/Page/NotificationsPage.elm
@@ -712,8 +712,8 @@ view appContext model =
                 All state ->
                     ( TabList.tabList [] tabs.all [ tabs.unread, tabs.archive ]
                     , viewSelectionControls state.selection
-                        [ Button.button (UpdateSelection Notification.Unread) "Mark as unread"
-                        , Button.button (UpdateSelection Notification.Read) "Mark as read"
+                        [ Button.button (UpdateSelection Notification.Read) "Mark as read"
+                        , Button.button (UpdateSelection Notification.Unread) "Mark as unread"
                         , Button.button (UpdateSelection Notification.Archived) "Archive"
                         ]
                     , view_ appContext model state.selection state.notifications


### PR DESCRIPTION
## Problem

"Mark as read" is second to "Mark as unread", but I think most people will mark as read more than unread.

## Solution

Swap it!

## Caveats/Notes

Couldn't test it out locally.
